### PR TITLE
Remove passthrough toggle from editor

### DIFF
--- a/Source/OnixSource.cpp
+++ b/Source/OnixSource.cpp
@@ -104,7 +104,7 @@ void OnixSource::initializeDevices(bool updateStreamInfo)
 
 	uint32_t val = 0;
 
-	if (getParameter("passthroughA")->getValue())
+	if (getParameter("passthroughA")->getValue() || getParameter("passthroughB")->getValue())
 	{
 		LOGD("Passthrough mode enabled");
 		val = 1;

--- a/Source/OnixSourceEditor.cpp
+++ b/Source/OnixSourceEditor.cpp
@@ -50,13 +50,13 @@ OnixSourceEditor::OnixSourceEditor(GenericProcessor* parentNode, OnixSource* oni
 	headstageComboBoxA->setSelectedId(1, dontSendNotification);
 	addAndMakeVisible(headstageComboBoxA.get());
 
-	passthroughEditorA = std::make_unique<ToggleParameterEditor>(onixSource->getParameter("passthroughA"));
-	passthroughEditorA->setLayout(ParameterEditor::nameHidden);
-	passthroughEditorA->setBounds(headstageComboBoxA->getX(), headstageComboBoxA->getBottom() + 4, 60, headstageComboBoxA->getHeight());
-	addAndMakeVisible(passthroughEditorA.get());
+	portVoltageOverrideLabelA = std::make_unique<Label>("voltageOverrideLabelA", "Voltage");
+	portVoltageOverrideLabelA->setBounds(headstageComboBoxA->getX(), headstageComboBoxA->getBottom() + 4, 50, headstageComboBoxA->getHeight());
+	portVoltageOverrideLabelA->setFont(fontOptionSmall);
+	addAndMakeVisible(portVoltageOverrideLabelA.get());
 
 	portVoltageValueA = std::make_unique<Label>("voltageValueA", "");
-	portVoltageValueA->setBounds(passthroughEditorA->getRight() + 10, passthroughEditorA->getY(), 35, passthroughEditorA->getHeight());
+	portVoltageValueA->setBounds(portVoltageOverrideLabelA->getRight() + 3, portVoltageOverrideLabelA->getY(), 25, portVoltageOverrideLabelA->getHeight());
 	portVoltageValueA->setFont(fontOptionSmall);
 	portVoltageValueA->setEditable(true);
 	portVoltageValueA->setColour(Label::textColourId, Colours::black);
@@ -66,7 +66,7 @@ OnixSourceEditor::OnixSourceEditor(GenericProcessor* parentNode, OnixSource* oni
 	addAndMakeVisible(portVoltageValueA.get());
 
 	portLabelB = std::make_unique<Label>("portLabelB", "Port B:");
-	portLabelB->setBounds(portLabelA->getX(), passthroughEditorA->getBottom() + 5, portLabelA->getWidth(), portLabelA->getHeight());
+	portLabelB->setBounds(portLabelA->getX(), portVoltageOverrideLabelA->getBottom() + 5, portLabelA->getWidth(), portLabelA->getHeight());
 	portLabelB->setFont(fontOptionTitle);
 	addAndMakeVisible(portLabelB.get());
 
@@ -83,13 +83,13 @@ OnixSourceEditor::OnixSourceEditor(GenericProcessor* parentNode, OnixSource* oni
 	headstageComboBoxB->setSelectedId(1, dontSendNotification);
 	addAndMakeVisible(headstageComboBoxB.get());
 
-	passthroughEditorB = std::make_unique<ToggleParameterEditor>(onixSource->getParameter("passthroughB"));
-	passthroughEditorB->setLayout(ParameterEditor::nameHidden);
-	passthroughEditorB->setBounds(headstageComboBoxB->getX(), headstageComboBoxB->getBottom() + 4, passthroughEditorA->getWidth(), passthroughEditorA->getHeight());
-	addAndMakeVisible(passthroughEditorB.get());
+	portVoltageOverrideLabelB = std::make_unique<Label>("voltageOverrideLabelB", "Voltage");
+	portVoltageOverrideLabelB->setBounds(headstageComboBoxB->getX(), headstageComboBoxB->getBottom() + 4, portVoltageOverrideLabelA->getWidth(), portVoltageOverrideLabelA->getHeight());
+	portVoltageOverrideLabelB->setFont(fontOptionSmall);
+	addAndMakeVisible(portVoltageOverrideLabelB.get());
 
 	portVoltageValueB = std::make_unique<Label>("voltageValueB", "");
-	portVoltageValueB->setBounds(passthroughEditorB->getRight() + 10, passthroughEditorB->getY(), portVoltageValueA->getWidth(), passthroughEditorB->getHeight());
+	portVoltageValueB->setBounds(portVoltageValueA->getX(), portVoltageOverrideLabelB->getY(), portVoltageValueA->getWidth(), portVoltageValueA->getHeight());
 	portVoltageValueB->setFont(fontOptionSmall);
 	portVoltageValueB->setEditable(true);
 	portVoltageValueB->setColour(Label::textColourId, Colours::black);
@@ -183,6 +183,15 @@ void OnixSourceEditor::comboBoxChanged(ComboBox* cb)
 		String headstage = headstageComboBoxA->getText();
 
 		thread->updateDiscoveryParameters(PortName::PortA, PortController::getHeadstageDiscoveryParameters(headstage));
+
+		if (headstage == "Neuropixels 1.0f")
+		{
+			thread->getParameter("passthroughA")->setNextValue(false);
+		}
+		else
+		{
+			thread->getParameter("passthroughA")->setNextValue(true);
+		}
 	}
 	else if (cb == headstageComboBoxB.get())
 	{
@@ -190,6 +199,15 @@ void OnixSourceEditor::comboBoxChanged(ComboBox* cb)
 		String headstage = headstageComboBoxB->getText();
 
 		thread->updateDiscoveryParameters(PortName::PortB, PortController::getHeadstageDiscoveryParameters(headstage));
+
+		if (headstage == "Neuropixels 1.0f")
+		{
+			thread->getParameter("passthroughB")->setNextValue(false);
+		}
+		else
+		{
+			thread->getParameter("passthroughB")->setNextValue(true);
+		}
 	}
 }
 

--- a/Source/OnixSourceEditor.h
+++ b/Source/OnixSourceEditor.h
@@ -88,13 +88,13 @@ private:
     std::unique_ptr<ComboBox> headstageComboBoxA;
     std::unique_ptr<ComboBox> headstageComboBoxB;
 
+    std::unique_ptr<Label> portVoltageOverrideLabelA;
+    std::unique_ptr<Label> portVoltageOverrideLabelB;
+
     std::unique_ptr<Label> portVoltageValueA;
     std::unique_ptr<Label> portVoltageValueB;
 
     std::unique_ptr<UtilityButton> connectButton;
-
-    std::unique_ptr<ToggleParameterEditor> passthroughEditorA;
-    std::unique_ptr<ToggleParameterEditor> passthroughEditorB;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OnixSourceEditor);
 };


### PR DESCRIPTION
Passthrough is now determined by the headstage selection in the combo box. 

- Fixes #8 