### PR TITLE
Add leak detectors to all classes

### DIFF
--- a/Source/Devices/Bno055.h
+++ b/Source/Devices/Bno055.h
@@ -84,6 +84,8 @@ private:
 
 	unsigned short currentFrame = 0;
 	int sampleNumber = 0;
+
+	JUCE_LEAK_DETECTOR(Bno055);
 };
 
 #endif

--- a/Source/Devices/HeadStageEEPROM.h
+++ b/Source/Devices/HeadStageEEPROM.h
@@ -17,5 +17,6 @@ private:
 	static const uint32_t EEPROM_ADDRESS = 0x51;
 	static const uint32_t DEVID_START_ADDR = 18;
 
+	JUCE_LEAK_DETECTOR(HeadStageEEPROM);
 };
 

--- a/Source/Devices/Neuropixels2e.h
+++ b/Source/Devices/Neuropixels2e.h
@@ -115,4 +115,5 @@ private:
 
 	Array<oni_frame_t*, CriticalSection, 2 * FramesPerSuperFrame> frameArray;
 
+	JUCE_LEAK_DETECTOR(Neuropixels2e);
 };

--- a/Source/Devices/Neuropixels_1.h
+++ b/Source/Devices/Neuropixels_1.h
@@ -254,6 +254,8 @@ private:
 	int lfpSampleNumber = 0;
 
 	OnixSource* source;
+
+	JUCE_LEAK_DETECTOR(Neuropixels_1);
 };
 
 /*
@@ -277,6 +279,8 @@ private:
 	Neuropixels_1* device;
 
 	std::atomic<int> result = 0;
+
+	JUCE_LEAK_DETECTOR(BackgroundUpdaterWithProgressWindow);
 };
 
 #endif

--- a/Source/FrameReader.h
+++ b/Source/FrameReader.h
@@ -42,6 +42,8 @@ private:
 
 	OwnedArray<OnixDevice>& sources;
 	oni_ctx& ctx;
+
+	JUCE_LEAK_DETECTOR(FrameReader);
 };
 
 #endif // __FRAMEREADER_H__

--- a/Source/OnixDevice.h
+++ b/Source/OnixDevice.h
@@ -35,7 +35,6 @@
 #include <onix.h>
 
 #include "I2CRegisterContext.h"
-#include "NeuropixComponents.h"
 
 #define ONI_OK(exp) {int res = exp; if (res != ONI_ESUCCESS){LOGD(oni_error_str(res));}}
 #define ONI_OK_RETURN_BOOL(exp) {int res = exp; if (res != ONI_ESUCCESS){LOGD(oni_error_str(res));return false;}}
@@ -125,6 +124,8 @@ private:
 	String name;
 
 	bool enabled = true;
+
+	JUCE_LEAK_DETECTOR(OnixDevice);
 };
 
 #endif

--- a/Source/OnixSource.cpp
+++ b/Source/OnixSource.cpp
@@ -192,8 +192,6 @@ void OnixSource::initializeDevices(bool updateStreamInfo)
 				}
 			}
 
-			np1->addSourceBuffers(sourceBuffers);
-
 			sources.add(np1.release());
 
 			npxProbeIdx++;
@@ -209,8 +207,6 @@ void OnixSource::initializeDevices(bool updateStreamInfo)
 				LOGE("Device Idx: ", devices[dev_idx].idx, " Error enabling device stream.");
 				continue;
 			}
-
-			bno->addSourceBuffers(sourceBuffers);
 
 			sources.add(bno.release());
 
@@ -241,8 +237,6 @@ void OnixSource::initializeDevices(bool updateStreamInfo)
 					continue;
 				}
 				npxProbeIdx += np2->getNumProbes();
-
-				np2->addSourceBuffers(sourceBuffers);
 
 				sources.add(np2.release());
 			}

--- a/Source/OnixSourceCanvas.cpp
+++ b/Source/OnixSourceCanvas.cpp
@@ -109,7 +109,6 @@ CustomViewport* OnixSourceCanvas::createCustomViewport(SettingsInterface* settin
 	return new CustomViewport(settingsInterface, bounds.getWidth(), bounds.getHeight());
 }
 
-
 OnixSourceCanvas::~OnixSourceCanvas()
 {
 }
@@ -149,33 +148,10 @@ void OnixSourceCanvas::refreshTabs()
 	topLevelTabComponent->setCurrentTabIndex(0);
 }
 
-void OnixSourceCanvas::update()
+void OnixSourceCanvas::update() const
 {
 	for (int i = 0; i < settingsInterfaces.size(); i++)
 		settingsInterfaces[i]->updateInfoString();
-
-	for (int i = 0; i < topLevelTabComponent->getNumTabs(); i++)
-	{
-		CustomTabComponent* t = (CustomTabComponent*)topLevelTabComponent->getTabContentComponent(i);
-
-		for (int j = 0; j < t->getNumTabs(); j++)
-		{
-			if (t->getTabContentComponent(j) != nullptr)
-			{
-				CustomViewport* v = (CustomViewport*)t->getTabContentComponent(j);
-
-				if (v != nullptr)
-				{
-					OnixDevice* device = v->settingsInterface->dataSource;
-
-					if (device != nullptr)
-						t->setTabName(j, " " + device->getName() + " ");
-					else
-						t->setTabName(j, "");
-				}
-			}
-		}
-	}
 }
 
 void OnixSourceCanvas::resized()
@@ -187,7 +163,7 @@ void OnixSourceCanvas::startAcquisition()
 {
 	for (auto settingsInterface : settingsInterfaces)
 	{
-		if (settingsInterface->dataSource != nullptr && settingsInterface->dataSource->isEnabled())
+		if (settingsInterface->device != nullptr && settingsInterface->device->isEnabled())
 		{
 			settingsInterface->startAcquisition();
 		}
@@ -198,7 +174,7 @@ void OnixSourceCanvas::stopAcquisition()
 {
 	for (auto settingsInterface : settingsInterfaces)
 	{
-		if (settingsInterface->dataSource != nullptr && settingsInterface->dataSource->isEnabled())
+		if (settingsInterface->device != nullptr && settingsInterface->device->isEnabled())
 		{
 			settingsInterface->stopAcquisition();
 		}

--- a/Source/OnixSourceCanvas.h
+++ b/Source/OnixSourceCanvas.h
@@ -70,6 +70,8 @@ public:
 private:
 	OnixSourceEditor* editor;
 	bool isTopLevel;
+
+	JUCE_LEAK_DETECTOR(CustomTabComponent);
 };
 
 /**
@@ -109,7 +111,7 @@ public:
 
 	/** Called when the Visualizer is first created, and optionally when
 		the parameters of the underlying processor are changed */
-	void update();
+	void update() const;
 
 	/** Starts animation of sub-interfaces */
 	void startAcquisition();
@@ -139,8 +141,6 @@ public:
 
 private:
 
-	Array<OnixDevice*> dataSources;
-
 	OnixSourceEditor* editor;
 
 	OnixSource* onixSource;
@@ -149,6 +149,8 @@ private:
 	OwnedArray<CustomTabComponent> portTabs;
 
 	Array<int> portTabIndex;
+
+	JUCE_LEAK_DETECTOR(OnixSourceCanvas);
 };
 
 # endif // __ONIXSOURCECANVAS_H__

--- a/Source/PortController.h
+++ b/Source/PortController.h
@@ -76,6 +76,8 @@ private:
 	const oni_reg_addr_t linkStateRegister = 5;
 
 	DiscoveryParameters discoveryParameters;
+
+	JUCE_LEAK_DETECTOR(PortController);
 };
 
 #endif // !__PORTCONTROLLER_H__

--- a/Source/UI/Bno055Interface.h
+++ b/Source/UI/Bno055Interface.h
@@ -59,6 +59,7 @@ public:
 
 private:
 
+	JUCE_LEAK_DETECTOR(Bno055Interface);
 };
 
 #endif // !__BNO055INTERFACE_H__

--- a/Source/UI/CustomViewport.h
+++ b/Source/UI/CustomViewport.h
@@ -76,6 +76,8 @@ private:
 
     int width;
     int height;
+
+    JUCE_LEAK_DETECTOR(CustomViewport);
 };
 
 #endif // __CUSTOMVIEWPORT_H__

--- a/Source/UI/NeuropixV1Interface.cpp
+++ b/Source/UI/NeuropixV1Interface.cpp
@@ -461,13 +461,11 @@ void NeuropixV1Interface::buttonClicked(Button* button)
 
 		if (fileChooser.browseForFileToOpen())
 		{
-			ProbeSettings settings = getProbeSettings();
-
-			bool success = ProbeInterfaceJson::readProbeSettingsFromJson(fileChooser.getResult(), settings);
+			bool success = ProbeInterfaceJson::readProbeSettingsFromJson(fileChooser.getResult(), device->settings);
 
 			if (success)
 			{
-				applyProbeSettings(settings);
+				applyProbeSettings(device->settings);
 			}
 		}
 	}
@@ -477,7 +475,7 @@ void NeuropixV1Interface::buttonClicked(Button* button)
 
 		if (fileChooser.browseForFileToSave(true))
 		{
-			bool success = ProbeInterfaceJson::writeProbeSettingsToJson(fileChooser.getResult(), getProbeSettings());
+			bool success = ProbeInterfaceJson::writeProbeSettingsToJson(fileChooser.getResult(), device->settings);
 
 			if (!success)
 				CoreServices::sendStatusMessage("Failed to write probe channel map.");
@@ -707,7 +705,7 @@ void NeuropixV1Interface::drawLegend(Graphics& g)
 	}
 }
 
-bool NeuropixV1Interface::applyProbeSettings(ProbeSettings p, bool shouldUpdateProbe)
+bool NeuropixV1Interface::applyProbeSettings(ProbeSettings& p, bool shouldUpdateProbe)
 {
 	if (electrodeConfigurationComboBox != 0)
 		electrodeConfigurationComboBox->setSelectedId(p.electrodeConfigurationIndex + 2, dontSendNotification);
@@ -760,11 +758,6 @@ bool NeuropixV1Interface::applyProbeSettings(ProbeSettings p, bool shouldUpdateP
 	repaint();
 
 	return true;
-}
-
-ProbeSettings NeuropixV1Interface::getProbeSettings() const
-{
-	return device->settings;
 }
 
 void NeuropixV1Interface::saveParameters(XmlElement* xml)

--- a/Source/UI/NeuropixV1Interface.h
+++ b/Source/UI/NeuropixV1Interface.h
@@ -29,11 +29,10 @@
 #include "../Devices/Neuropixels_1.h"
 #include "ColourScheme.h"
 #include "SettingsInterface.h"
+#include "ProbeBrowser.h"
 
 #include "../OnixSourceEditor.h"
 #include "../OnixSourceCanvas.h"
-
-class ProbeBrowser;
 
 enum class VisualizationMode
 {
@@ -94,8 +93,7 @@ public:
 	void stopAcquisition() override;
 
 	/** Settings-related functions*/
-	bool applyProbeSettings(ProbeSettings p, bool shouldUpdateProbe = true);
-	ProbeSettings getProbeSettings() const;
+	bool applyProbeSettings(ProbeSettings& p, bool shouldUpdateProbe = true);
 
 	/** Save parameters to XML */
 	void saveParameters(XmlElement* xml) override;
@@ -175,6 +173,8 @@ private:
 	Array<int> getSelectedElectrodes() const;
 
 	void setInterfaceEnabledState(bool enabledState);
+
+	JUCE_LEAK_DETECTOR(NeuropixV1Interface);
 };
 
 #endif //__NEUROPIXINTERFACE_H__

--- a/Source/UI/ProbeBrowser.h
+++ b/Source/UI/ProbeBrowser.h
@@ -26,13 +26,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <VisualizerEditorHeaders.h>
 
-#include "NeuropixV1Interface.h"
+#include "SettingsInterface.h"
+#include "../NeuropixComponents.h"
 
 class ProbeBrowser : public Component,
                      public Timer
 {
 public:
-    ProbeBrowser (NeuropixV1Interface*);
+    ProbeBrowser (SettingsInterface*);
     virtual ~ProbeBrowser();
 
     void mouseMove (const MouseEvent& event);
@@ -99,7 +100,9 @@ private:
     Array<int> getElectrodesWithinBounds (int x, int y, int w, int h) const;
     String getElectrodeInfoString (int index);
 
-    NeuropixV1Interface* parent;
+    SettingsInterface* parent;
+
+    JUCE_LEAK_DETECTOR(ProbeBrowser);
 };
 
 #endif  // __PROBEBROWSER_H__

--- a/Source/UI/SettingsInterface.h
+++ b/Source/UI/SettingsInterface.h
@@ -49,9 +49,9 @@ public:
     };
 
     /** Constructor */
-    SettingsInterface (OnixDevice* dataSource_, OnixSourceEditor* editor_, OnixSourceCanvas* canvas_)
+    SettingsInterface (OnixDevice* device_, OnixSourceEditor* editor_, OnixSourceCanvas* canvas_)
     {
-        dataSource = dataSource_;
+        device = device_;
         editor = editor_;
         canvas = canvas_;
 
@@ -83,11 +83,13 @@ public:
     Type type = Type::UNKNOWN_SETTINGS_INTERFACE;
 
     /** Pointer to the data source*/
-    OnixDevice* dataSource;
+    OnixDevice* device;
 
 protected:
     OnixSourceEditor* editor;
     OnixSourceCanvas* canvas;
+
+    JUCE_LEAK_DETECTOR(SettingsInterface);
 };
 
 #endif //__SETTINGSINTERFACE_H__


### PR DESCRIPTION
To make #12 easier to fix, this PR adds leak detectors to all classes. There is also some code cleanup related to these classes, renaming variables so they are less confusing, and removing local declarations of variables if they can be easily accessed via pointer.

- Fixes #11 