### PR TITLE
Correct for Neuropixels data offsets

### DIFF
--- a/Source/Devices/Neuropixels_1.cpp
+++ b/Source/Devices/Neuropixels_1.cpp
@@ -478,8 +478,9 @@ void Neuropixels_1::processFrames()
 				for (int adc = 0; adc < 32; adc++)
 				{
 					int chanIndex = adcToChannel[adc] + superCountOffset * 2; // map the ADC to muxed channel
+					float offset = shouldCorrectOffset ? lfpOffsets.at(chanIndex) : 0.0f;
 					lfpSamples[(chanIndex * numUltraFrames) + ultraFrameCount] =
-						lfpConversion * float((*(dataPtr + adcToFrameIndex[adc] + dataOffset) >> 5) - 512) - lfpOffsets.at(chanIndex);
+						lfpConversion * float((*(dataPtr + adcToFrameIndex[adc] + dataOffset) >> 5) - 512) - offset;
 				}
 			}
 			else // AP data
@@ -488,8 +489,9 @@ void Neuropixels_1::processFrames()
 				for (int adc = 0; adc < 32; adc++)
 				{
 					int chanIndex = adcToChannel[adc] + chanOffset; //  map the ADC to muxed channel.
+					float offset = shouldCorrectOffset ? apOffsets.at(chanIndex) : 0.0f;
 					apSamples[(chanIndex * superFramesPerUltraFrame * numUltraFrames) + superFrameCount] =
-						apConversion * float((*(dataPtr + adcToFrameIndex[adc] + i * 36 + dataOffset) >> 5) - 512) - apOffsets.at(chanIndex);
+						apConversion * float((*(dataPtr + adcToFrameIndex[adc] + i * 36 + dataOffset) >> 5) - 512) - offset;
 				}
 			}
 		}

--- a/Source/Devices/Neuropixels_1.cpp
+++ b/Source/Devices/Neuropixels_1.cpp
@@ -391,13 +391,13 @@ void Neuropixels_1::startAcquisition()
 	lfpOffsetValues.clear();
 	lfpOffsetValues.reserve(numberOfChannels);
 
-	for (int i = 0; i < numberOfChannels; i += 1)
+	for (int i = 0; i < numberOfChannels; i++)
 	{
 		apOffsets[i] = 0;
 		lfpOffsets[i] = 0;
 
-		apOffsetValues.push_back(std::vector<float>{});
-		lfpOffsetValues.push_back(std::vector<float>{});
+		apOffsetValues.emplace_back(std::vector<float>{});
+		lfpOffsetValues.emplace_back(std::vector<float>{});
 	}
 
 	lfpOffsetCalculated = false;
@@ -526,25 +526,25 @@ void Neuropixels_1::processFrames()
 
 void Neuropixels_1::updateApOffsets(std::array<float, numApSamples>& samples, int64 sampleNumber)
 {
-	if (sampleNumber > apSampleRate * 5)
+	if (sampleNumber > apSampleRate * secondsToSettle)
 	{
 		uint32_t counter = 0;
 
-		while (apOffsetValues[0].size() <= 99)
+		while (apOffsetValues[0].size() < samplesToAverage)
 		{
 			if (counter >= superFramesPerUltraFrame * numUltraFrames) break;
 
-			for (int i = 0; i < numberOfChannels; i += 1)
+			for (int i = 0; i < numberOfChannels; i++)
 			{
-				apOffsetValues[i].push_back(samples[i * superFramesPerUltraFrame * numUltraFrames + counter]);
+				apOffsetValues[i].emplace_back(samples[i * superFramesPerUltraFrame * numUltraFrames + counter]);
 			}
 
-			counter += 1;
+			counter++;
 		}
 
-		if (apOffsetValues[0].size() >= 100)
+		if (apOffsetValues[0].size() >= samplesToAverage)
 		{
-			for (int i = 0; i < numberOfChannels; i += 1)
+			for (int i = 0; i < numberOfChannels; i++)
 			{
 				apOffsets[i] = std::reduce(apOffsetValues.at(i).begin(), apOffsetValues.at(i).end()) / apOffsetValues.at(i).size();
 			}
@@ -557,25 +557,25 @@ void Neuropixels_1::updateApOffsets(std::array<float, numApSamples>& samples, in
 
 void Neuropixels_1::updateLfpOffsets(std::array<float, numLfpSamples>& samples, int64 sampleNumber)
 {
-	if (sampleNumber > lfpSampleRate * 5)
+	if (sampleNumber > lfpSampleRate * secondsToSettle)
 	{
 		uint32_t counter = 0;
 
-		while (lfpOffsetValues[0].size() <= 99)
+		while (lfpOffsetValues[0].size() < samplesToAverage)
 		{
 			if (counter >= numUltraFrames) break;
 
-			for (int i = 0; i < numberOfChannels; i += 1)
+			for (int i = 0; i < numberOfChannels; i++)
 			{
-				lfpOffsetValues[i].push_back(samples[i * numUltraFrames + counter]);
+				lfpOffsetValues[i].emplace_back(samples[i * numUltraFrames + counter]);
 			}
 
-			counter += 1;
+			counter++;
 		}
 
-		if (lfpOffsetValues[0].size() >= 100)
+		if (lfpOffsetValues[0].size() >= samplesToAverage)
 		{
-			for (int i = 0; i < numberOfChannels; i += 1)
+			for (int i = 0; i < numberOfChannels; i++)
 			{
 				lfpOffsets[i] = std::reduce(lfpOffsetValues.at(i).begin(), lfpOffsetValues.at(i).end()) / lfpOffsetValues.at(i).size();
 			}

--- a/Source/Devices/Neuropixels_1.h
+++ b/Source/Devices/Neuropixels_1.h
@@ -225,6 +225,9 @@ private:
 	static const int numUltraFrames = 12;
 	static const int dataOffset = 1;
 
+	static const int secondsToSettle = 5;
+	static const int samplesToAverage = 100;
+
 	static const uint32_t numLfpSamples = 384 * numUltraFrames;
 	static const uint32_t numApSamples = 384 * numUltraFrames * superFramesPerUltraFrame;
 

--- a/Source/Devices/Neuropixels_1.h
+++ b/Source/Devices/Neuropixels_1.h
@@ -210,6 +210,10 @@ public:
 	String adcCalibrationFilePath;
 	String gainCalibrationFilePath;
 
+	bool getShouldCorrectOffset() const { return shouldCorrectOffset; }
+
+	void setShouldCorrectOffset(bool value) { shouldCorrectOffset = value; }
+
 private:
 
 	DataBuffer* apBuffer;
@@ -269,6 +273,8 @@ private:
 
 	int apGain = 1000;
 	int lfpGain = 50;
+
+	bool shouldCorrectOffset = true;
 
 	JUCE_LEAK_DETECTOR(Neuropixels_1);
 };

--- a/Source/Devices/Neuropixels_1.h
+++ b/Source/Devices/Neuropixels_1.h
@@ -236,8 +236,8 @@ private:
 	std::vector<std::vector<float>> apOffsetValues;
 	std::vector<std::vector<float>> lfpOffsetValues;
 
-	void updateLfpOffsets(std::array<float, numLfpSamples>&, int64 timestamp);
-	void updateApOffsets(std::array<float, numApSamples>&, int64 timestamp);
+	void updateLfpOffsets(std::array<float, numLfpSamples>&, int64);
+	void updateApOffsets(std::array<float, numApSamples>&, int64);
 
 	static const int ProbeI2CAddress = 0x70;
 

--- a/Source/Devices/Neuropixels_1.h
+++ b/Source/Devices/Neuropixels_1.h
@@ -221,8 +221,23 @@ private:
 	static const int numUltraFrames = 12;
 	static const int dataOffset = 1;
 
+	static const uint32_t numLfpSamples = 384 * numUltraFrames;
+	static const uint32_t numApSamples = 384 * numUltraFrames * superFramesPerUltraFrame;
+
 	const float lfpSampleRate = 2500.0f;
 	const float apSampleRate = 30000.0f;
+
+	bool lfpOffsetCalculated = false;
+	bool apOffsetCalculated = false;
+
+	std::array<float, numberOfChannels> apOffsets;
+	std::array<float, numberOfChannels> lfpOffsets;
+
+	std::vector<std::vector<float>> apOffsetValues;
+	std::vector<std::vector<float>> lfpOffsetValues;
+
+	void updateLfpOffsets(std::array<float, numLfpSamples>&, int64 timestamp);
+	void updateApOffsets(std::array<float, numApSamples>&, int64 timestamp);
 
 	static const int ProbeI2CAddress = 0x70;
 
@@ -234,8 +249,8 @@ private:
 
 	int64 probeNumber = 0;
 
-	float lfpSamples[384 * numUltraFrames];
-	float apSamples[384 * numUltraFrames * superFramesPerUltraFrame];
+	std::array<float, numLfpSamples> lfpSamples;
+	std::array<float, numApSamples> apSamples;
 
 	int64 apSampleNumbers[numUltraFrames * superFramesPerUltraFrame];
 	double apTimestamps[numUltraFrames * superFramesPerUltraFrame];

--- a/Source/OnixSource.cpp
+++ b/Source/OnixSource.cpp
@@ -168,7 +168,7 @@ void OnixSource::initializeDevices(bool updateStreamInfo)
 				}
 			}
 
-			sources.push_back(np1);
+			sources.emplace_back(np1);
 			headstages.insert({ PortController::getPortFromIndex(index), NEUROPIXELSV1F_HEADSTAGE_NAME });
 
 			npxProbeIdx++;
@@ -185,7 +185,7 @@ void OnixSource::initializeDevices(bool updateStreamInfo)
 				continue;
 			}
 
-			sources.push_back(bno);
+			sources.emplace_back(bno);
 		}
 		else if (device.id == ONIX_DS90UB9RAW)
 		{
@@ -213,7 +213,7 @@ void OnixSource::initializeDevices(bool updateStreamInfo)
 				}
 				npxProbeIdx += np2->getNumProbes();
 
-				sources.push_back(np2);
+				sources.emplace_back(np2);
 			}
 		}
 	}
@@ -242,7 +242,7 @@ OnixDeviceVector OnixSource::getDataSources() const
 
 	for (const auto& source : sources)
 	{
-		devices.push_back(source);
+		devices.emplace_back(source);
 	}
 
 	return devices;
@@ -255,7 +255,7 @@ OnixDeviceVector OnixSource::getDataSourcesFromPort(PortName port) const
 	for (const auto& source : sources)
 	{
 		if (PortController::getPortFromIndex(source->getDeviceIdx()) == port)
-			devices.push_back(source);
+			devices.emplace_back(source);
 	}
 
 	return devices;
@@ -494,11 +494,11 @@ bool OnixSource::startAcquisition()
 
 	for (const auto& source : sources)
 	{
-		devices.push_back(source);
+		devices.emplace_back(source);
 	}
 
-	devices.push_back(portA);
-	devices.push_back(portB);
+	devices.emplace_back(portA);
+	devices.emplace_back(portB);
 
 	for (const auto& source : devices)
 	{

--- a/Source/OnixSource.cpp
+++ b/Source/OnixSource.cpp
@@ -35,12 +35,24 @@ OnixSource::OnixSource(SourceNode* sn) :
 	}
 	catch (const std::system_error& e)
 	{
-		LOGE("Failed to create context.");
+		LOGE("Failed to create context. ", e.what());
+		CoreServices::sendStatusMessage("Failed to create context." + String(e.what()));
+		AlertWindow::showMessageBox(
+			MessageBoxIconType::WarningIcon,
+			"Failed to Create Context",
+			"There was an error creating the context. Check the error logs for more details."
+		);
 		return;
 	}
 	catch (const error_t& e)
 	{
 		LOGE("Failed to initialize context. ", e.what());
+		CoreServices::sendStatusMessage("Failed to create context. " + String(e.what()));
+		AlertWindow::showMessageBox(
+			MessageBoxIconType::WarningIcon,
+			"Failed to Initialize Context",
+			"There was an error initializing the context. Check the error logs for more details."
+		);
 		return;
 	}
 

--- a/Source/OnixSource.h
+++ b/Source/OnixSource.h
@@ -88,6 +88,8 @@ public:
 
 	void resetContext() { if (context != nullptr && context->isInitialized()) context->issueReset(); }
 
+	bool isContextInitialized() { return context != nullptr && context->isInitialized(); }
+
 	void initializeDevices(bool updateStreamInfo = false);
 
 	void disconnectDevices(bool updateStreamInfo = false);

--- a/Source/OnixSourceCanvas.cpp
+++ b/Source/OnixSourceCanvas.cpp
@@ -139,8 +139,11 @@ void OnixSourceCanvas::updateSettingsInterfaceDataSource(std::shared_ptr<OnixDev
 	if (device->type == OnixDeviceType::NEUROPIXELS_1)
 	{
 		// NB: Neuropixels-specific settings need to be updated
-		auto npx1 = std::static_pointer_cast<Neuropixels_1>(device);
-		npx1->setSettings(std::static_pointer_cast<Neuropixels_1>(settingsInterfaces[ind]->device)->settings.get());
+		auto npx1Found = std::static_pointer_cast<Neuropixels_1>(device);
+		auto npx1Selected = std::static_pointer_cast<Neuropixels_1>(settingsInterfaces[ind]->device);
+		npx1Found->setSettings(npx1Selected->settings.get());
+		npx1Found->adcCalibrationFilePath = npx1Selected->adcCalibrationFilePath;
+		npx1Found->gainCalibrationFilePath = npx1Selected->gainCalibrationFilePath;
 	}
 	// TODO: Add more devices, since they will have device-specific settings to be updated
 

--- a/Source/OnixSourceCanvas.cpp
+++ b/Source/OnixSourceCanvas.cpp
@@ -84,9 +84,9 @@ void OnixSourceCanvas::addHeadstage(String headstage, PortName port)
 	{
 		tab = addTopLevelTab(getTopLevelTabName(port, headstage), (int)port - 1);
 
-		devices.push_back(std::make_shared<Neuropixels_1>("Probe-A", offset, nullptr));
-		devices.push_back(std::make_shared<Neuropixels_1>("Probe-B", offset + 1, nullptr));
-		devices.push_back(std::make_shared<Bno055>("BNO055", offset + 2, nullptr));
+		devices.emplace_back(std::make_shared<Neuropixels_1>("Probe-A", offset, nullptr));
+		devices.emplace_back(std::make_shared<Neuropixels_1>("Probe-B", offset + 1, nullptr));
+		devices.emplace_back(std::make_shared<Bno055>("BNO055", offset + 2, nullptr));
 	}
 
 	if (tab != nullptr && devices.size() > 0)
@@ -116,7 +116,7 @@ void OnixSourceCanvas::populateSourceTabs(CustomTabComponent* tab, OnixDeviceVec
 
 void OnixSourceCanvas::addInterfaceToTab(String tabName, CustomTabComponent* tab, std::shared_ptr<SettingsInterface> interface_)
 {
-	settingsInterfaces.push_back(interface_);
+	settingsInterfaces.emplace_back(interface_);
 	tab->addTab(tabName, Colours::darkgrey, createCustomViewport(interface_.get()), true);
 }
 
@@ -124,7 +124,7 @@ void OnixSourceCanvas::updateSettingsInterfaceDataSource(std::shared_ptr<OnixDev
 {
 	int ind = -1;
 
-	for (int j = 0; j < settingsInterfaces.size(); j += 1)
+	for (int j = 0; j < settingsInterfaces.size(); j++)
 	{
 		if (device->getDeviceIdx() == settingsInterfaces[j]->device->getDeviceIdx() &&
 			device->getName() == settingsInterfaces[j]->device->getName())
@@ -323,8 +323,8 @@ void OnixSourceCanvas::refreshTabs()
 	{
 		std::vector<int> selectedIndices, foundIndices;
 
-		for (const auto& [key, _] : selectedMap) { selectedIndices.push_back(key); }
-		for (const auto& [key, _] : foundMap) { foundIndices.push_back(key); }
+		for (const auto& [key, _] : selectedMap) { selectedIndices.emplace_back(key); }
+		for (const auto& [key, _] : foundMap) { foundIndices.emplace_back(key); }
 
 		auto selectedPorts = PortController::getUniquePortsFromIndices(selectedIndices);
 		auto foundPorts = PortController::getUniquePortsFromIndices(foundIndices);

--- a/Source/OnixSourceEditor.cpp
+++ b/Source/OnixSourceEditor.cpp
@@ -240,8 +240,8 @@ void OnixSourceEditor::updateComboBox(ComboBox* cb)
 	std::vector<int> deviceIndices;
 	std::vector<int> tabIndices;
 
-	for (auto& [key, _] : deviceMap) { deviceIndices.push_back(key); }
-	for (auto& [key, _] : tabMap) { tabIndices.push_back(key); }
+	for (auto& [key, _] : deviceMap) { deviceIndices.emplace_back(key); }
+	for (auto& [key, _] : tabMap) { tabIndices.emplace_back(key); }
 
 	auto devicePorts = PortController::getUniquePortsFromIndices(deviceIndices);
 	auto tabPorts = PortController::getUniquePortsFromIndices(tabIndices);
@@ -367,7 +367,7 @@ String OnixSourceEditor::getHeadstageSelected(PortName port)
 
 void OnixSourceEditor::setComboBoxSelection(ComboBox* comboBox, String headstage)
 {
-	for (int i = 0; i < comboBox->getNumItems(); i += 1)
+	for (int i = 0; i < comboBox->getNumItems(); i++)
 	{
 		if (headstage.contains(comboBox->getItemText(i)))
 		{

--- a/Source/OnixSourceEditor.cpp
+++ b/Source/OnixSourceEditor.cpp
@@ -32,72 +32,75 @@ OnixSourceEditor::OnixSourceEditor(GenericProcessor* parentNode, OnixSource* sou
 	FontOptions fontOptionSmall = FontOptions("Fira Code", "Regular", 12.0f);
 	FontOptions fontOptionTitle = FontOptions("Fira Code", "Bold", 15.0f);
 
-	portLabelA = std::make_unique<Label>("portLabelA", "Port A:");
-	portLabelA->setBounds(4, 25, 60, 16);
-	portLabelA->setFont(fontOptionTitle);
-	addAndMakeVisible(portLabelA.get());
+	if (source->isContextInitialized())
+	{
+		portLabelA = std::make_unique<Label>("portLabelA", "Port A:");
+		portLabelA->setBounds(4, 25, 60, 16);
+		portLabelA->setFont(fontOptionTitle);
+		addAndMakeVisible(portLabelA.get());
 
-	headstageComboBoxA = std::make_unique<ComboBox>("headstageComboBoxA");
-	headstageComboBoxA->setBounds(portLabelA->getRight() + 2, portLabelA->getY(), 120, portLabelA->getHeight());
-	headstageComboBoxA->addListener(this);
-	headstageComboBoxA->setTooltip("Select the headstage connected to port A.");
-	addHeadstageComboBoxOptions(headstageComboBoxA.get());
-	headstageComboBoxA->setSelectedId(1, dontSendNotification);
-	addAndMakeVisible(headstageComboBoxA.get());
+		headstageComboBoxA = std::make_unique<ComboBox>("headstageComboBoxA");
+		headstageComboBoxA->setBounds(portLabelA->getRight() + 2, portLabelA->getY(), 120, portLabelA->getHeight());
+		headstageComboBoxA->addListener(this);
+		headstageComboBoxA->setTooltip("Select the headstage connected to port A.");
+		addHeadstageComboBoxOptions(headstageComboBoxA.get());
+		headstageComboBoxA->setSelectedId(1, dontSendNotification);
+		addAndMakeVisible(headstageComboBoxA.get());
 
-	portVoltageOverrideLabelA = std::make_unique<Label>("voltageOverrideLabelA", "Voltage:");
-	portVoltageOverrideLabelA->setBounds(portLabelA->getX() + 15, headstageComboBoxA->getBottom() + 4, 62, headstageComboBoxA->getHeight());
-	portVoltageOverrideLabelA->setFont(fontOptionSmall);
-	addAndMakeVisible(portVoltageOverrideLabelA.get());
+		portVoltageOverrideLabelA = std::make_unique<Label>("voltageOverrideLabelA", "Voltage:");
+		portVoltageOverrideLabelA->setBounds(portLabelA->getX() + 15, headstageComboBoxA->getBottom() + 4, 62, headstageComboBoxA->getHeight());
+		portVoltageOverrideLabelA->setFont(fontOptionSmall);
+		addAndMakeVisible(portVoltageOverrideLabelA.get());
 
-	portVoltageValueA = std::make_unique<Label>("voltageValueA", "Auto");
-	portVoltageValueA->setBounds(portVoltageOverrideLabelA->getRight() + 3, portVoltageOverrideLabelA->getY(), 40, portVoltageOverrideLabelA->getHeight());
-	portVoltageValueA->setFont(fontOptionSmall);
-	portVoltageValueA->setEditable(true);
-	portVoltageValueA->setColour(Label::textColourId, Colours::black);
-	portVoltageValueA->setColour(Label::backgroundColourId, Colours::lightgrey);
-	portVoltageValueA->setTooltip("Voltage override. If set, overrides the automated voltage discovery algorithm.");
-	portVoltageValueA->addListener(this);
-	addAndMakeVisible(portVoltageValueA.get());
+		portVoltageValueA = std::make_unique<Label>("voltageValueA", "Auto");
+		portVoltageValueA->setBounds(portVoltageOverrideLabelA->getRight() + 3, portVoltageOverrideLabelA->getY(), 40, portVoltageOverrideLabelA->getHeight());
+		portVoltageValueA->setFont(fontOptionSmall);
+		portVoltageValueA->setEditable(true);
+		portVoltageValueA->setColour(Label::textColourId, Colours::black);
+		portVoltageValueA->setColour(Label::backgroundColourId, Colours::lightgrey);
+		portVoltageValueA->setTooltip("Voltage override. If set, overrides the automated voltage discovery algorithm.");
+		portVoltageValueA->addListener(this);
+		addAndMakeVisible(portVoltageValueA.get());
 
-	portLabelB = std::make_unique<Label>("portLabelB", "Port B:");
-	portLabelB->setBounds(portLabelA->getX(), portVoltageOverrideLabelA->getBottom() + 5, portLabelA->getWidth(), portLabelA->getHeight());
-	portLabelB->setFont(fontOptionTitle);
-	addAndMakeVisible(portLabelB.get());
+		portLabelB = std::make_unique<Label>("portLabelB", "Port B:");
+		portLabelB->setBounds(portLabelA->getX(), portVoltageOverrideLabelA->getBottom() + 5, portLabelA->getWidth(), portLabelA->getHeight());
+		portLabelB->setFont(fontOptionTitle);
+		addAndMakeVisible(portLabelB.get());
 
-	headstageComboBoxB = std::make_unique<ComboBox>("headstageComboBoxB");
-	headstageComboBoxB->setBounds(portLabelB->getRight(), portLabelB->getY(), headstageComboBoxA->getWidth(), portLabelB->getHeight());
-	headstageComboBoxB->addListener(this);
-	headstageComboBoxB->setTooltip("Select the headstage connected to port B.");
-	addHeadstageComboBoxOptions(headstageComboBoxB.get());
+		headstageComboBoxB = std::make_unique<ComboBox>("headstageComboBoxB");
+		headstageComboBoxB->setBounds(portLabelB->getRight(), portLabelB->getY(), headstageComboBoxA->getWidth(), portLabelB->getHeight());
+		headstageComboBoxB->addListener(this);
+		headstageComboBoxB->setTooltip("Select the headstage connected to port B.");
+		addHeadstageComboBoxOptions(headstageComboBoxB.get());
 
-	headstageComboBoxB->setSelectedId(1, dontSendNotification);
-	addAndMakeVisible(headstageComboBoxB.get());
+		headstageComboBoxB->setSelectedId(1, dontSendNotification);
+		addAndMakeVisible(headstageComboBoxB.get());
 
-	portVoltageOverrideLabelB = std::make_unique<Label>("voltageOverrideLabelB", "Voltage:");
-	portVoltageOverrideLabelB->setBounds(portVoltageOverrideLabelA->getX(), headstageComboBoxB->getBottom() + 4, portVoltageOverrideLabelA->getWidth(), portVoltageOverrideLabelA->getHeight());
-	portVoltageOverrideLabelB->setFont(fontOptionSmall);
-	addAndMakeVisible(portVoltageOverrideLabelB.get());
+		portVoltageOverrideLabelB = std::make_unique<Label>("voltageOverrideLabelB", "Voltage:");
+		portVoltageOverrideLabelB->setBounds(portVoltageOverrideLabelA->getX(), headstageComboBoxB->getBottom() + 4, portVoltageOverrideLabelA->getWidth(), portVoltageOverrideLabelA->getHeight());
+		portVoltageOverrideLabelB->setFont(fontOptionSmall);
+		addAndMakeVisible(portVoltageOverrideLabelB.get());
 
-	portVoltageValueB = std::make_unique<Label>("voltageValueB", "Auto");
-	portVoltageValueB->setBounds(portVoltageValueA->getX(), portVoltageOverrideLabelB->getY(), portVoltageValueA->getWidth(), portVoltageValueA->getHeight());
-	portVoltageValueB->setFont(fontOptionSmall);
-	portVoltageValueB->setEditable(true);
-	portVoltageValueB->setColour(Label::textColourId, Colours::black);
-	portVoltageValueB->setColour(Label::backgroundColourId, Colours::lightgrey);
-	portVoltageValueB->setTooltip("Voltage override. If set, overrides the automated voltage discovery algorithm.");
-	portVoltageValueB->addListener(this);
-	addAndMakeVisible(portVoltageValueB.get());
+		portVoltageValueB = std::make_unique<Label>("voltageValueB", "Auto");
+		portVoltageValueB->setBounds(portVoltageValueA->getX(), portVoltageOverrideLabelB->getY(), portVoltageValueA->getWidth(), portVoltageValueA->getHeight());
+		portVoltageValueB->setFont(fontOptionSmall);
+		portVoltageValueB->setEditable(true);
+		portVoltageValueB->setColour(Label::textColourId, Colours::black);
+		portVoltageValueB->setColour(Label::backgroundColourId, Colours::lightgrey);
+		portVoltageValueB->setTooltip("Voltage override. If set, overrides the automated voltage discovery algorithm.");
+		portVoltageValueB->addListener(this);
+		addAndMakeVisible(portVoltageValueB.get());
 
-	connectButton = std::make_unique<UtilityButton>("CONNECT");
-	connectButton->setFont(fontOptionSmall);
-	connectButton->setBounds(portLabelB->getX() + 5, portLabelB->getBottom() + 25, 70, 18);
-	connectButton->setRadius(3.0f);
-	connectButton->setClickingTogglesState(true);
-	connectButton->setToggleState(false, dontSendNotification);
-	connectButton->setTooltip("Press to connect or disconnect from Onix hardware");
-	connectButton->addListener(this);
-	addAndMakeVisible(connectButton.get());
+		connectButton = std::make_unique<UtilityButton>("CONNECT");
+		connectButton->setFont(fontOptionSmall);
+		connectButton->setBounds(portLabelB->getX() + 5, portLabelB->getBottom() + 25, 70, 18);
+		connectButton->setRadius(3.0f);
+		connectButton->setClickingTogglesState(true);
+		connectButton->setToggleState(false, dontSendNotification);
+		connectButton->setTooltip("Press to connect or disconnect from Onix hardware");
+		connectButton->addListener(this);
+		addAndMakeVisible(connectButton.get());
+	}
 }
 
 void OnixSourceEditor::addHeadstageComboBoxOptions(ComboBox* comboBox)

--- a/Source/UI/NeuropixV1Interface.cpp
+++ b/Source/UI/NeuropixV1Interface.cpp
@@ -159,13 +159,13 @@ NeuropixV1Interface::NeuropixV1Interface(std::shared_ptr<Neuropixels_1> d, OnixS
 		enableViewButton->setTooltip("View electrode enabled state");
 		addAndMakeVisible(enableViewButton.get());
 
-		selectElctrodeButton = std::make_unique<UtilityButton>("SELECT");
-		selectElctrodeButton->setFont(fontRegularButton);
-		selectElctrodeButton->setRadius(3.0f);
-		selectElctrodeButton->setBounds(450, currentHeight, 65, 22);
-		selectElctrodeButton->addListener(this);
-		selectElctrodeButton->setTooltip("Enable selected electrodes");
-		addAndMakeVisible(selectElctrodeButton.get());
+		selectElectrodeButton = std::make_unique<UtilityButton>("SELECT");
+		selectElectrodeButton->setFont(fontRegularButton);
+		selectElectrodeButton->setRadius(3.0f);
+		selectElectrodeButton->setBounds(450, currentHeight, 65, 22);
+		selectElectrodeButton->addListener(this);
+		selectElectrodeButton->setTooltip("Enable selected electrodes");
+		addAndMakeVisible(selectElectrodeButton.get());
 
 		currentHeight += 58;
 
@@ -333,7 +333,7 @@ NeuropixV1Interface::NeuropixV1Interface(std::shared_ptr<Neuropixels_1> d, OnixS
 		enableViewComponent = std::make_unique<Component>("enableViewComponent");
 		enableViewComponent->setBounds(450, 430, 120, 200);
 
-		enableViewLabels.push_back(std::make_unique<Label>("enableViewLabel", "ENABLED?"));
+		enableViewLabels.emplace_back(std::make_unique<Label>("enableViewLabel", "ENABLED?"));
 		enableViewLabels[0]->setJustificationType(Justification::centredLeft);
 		enableViewLabels[0]->setFont(FontOptions(fontSize));
 		enableViewLabels[0]->setColour(Label::ColourIds::textColourId, colour);
@@ -343,14 +343,14 @@ NeuropixV1Interface::NeuropixV1Interface(std::shared_ptr<Neuropixels_1> d, OnixS
 		std::vector<Colour> colors = { Colours::yellow, Colours::darkgrey, Colours::black };
 		StringArray legendLabels = { "YES", "NO", "REFERENCE" };
 
-		for (int i = 0; i < colors.size(); i += 1)
+		for (int i = 0; i < colors.size(); i++)
 		{
-			enableViewRectangles.push_back(std::make_unique<DrawableRectangle>());
+			enableViewRectangles.emplace_back(std::make_unique<DrawableRectangle>());
 			enableViewRectangles[i]->setFill(colors[i]);
 			enableViewRectangles[i]->setRectangle(Rectangle<float>(enableViewLabels[0]->getX() + 6, enableViewLabels[i]->getBottom() + 1, 12, 12));
 			enableViewComponent->addAndMakeVisible(enableViewRectangles[i].get());
 
-			enableViewLabels.push_back(std::make_unique<Label>("enableViewLabel", legendLabels[i]));
+			enableViewLabels.emplace_back(std::make_unique<Label>("enableViewLabel", legendLabels[i]));
 			int labelInd = i + 1;
 			enableViewLabels[labelInd]->setJustificationType(Justification::centredLeft);
 			enableViewLabels[labelInd]->setFont(FontOptions(fontSize));
@@ -365,7 +365,7 @@ NeuropixV1Interface::NeuropixV1Interface(std::shared_ptr<Neuropixels_1> d, OnixS
 		apGainViewComponent = std::make_unique<Component>("apGainViewComponent");
 		apGainViewComponent->setBounds(enableViewComponent->getX(), enableViewComponent->getY(), 120, 300);
 
-		apGainViewLabels.push_back(std::make_unique<Label>("apGainViewLabel", "AP GAIN"));
+		apGainViewLabels.emplace_back(std::make_unique<Label>("apGainViewLabel", "AP GAIN"));
 		apGainViewLabels[0]->setJustificationType(Justification::centredLeft);
 		apGainViewLabels[0]->setFont(FontOptions(fontSize));
 		apGainViewLabels[0]->setColour(Label::ColourIds::textColourId, colour);
@@ -375,20 +375,20 @@ NeuropixV1Interface::NeuropixV1Interface(std::shared_ptr<Neuropixels_1> d, OnixS
 		colors.clear();
 		legendLabels.clear();
 
-		for (int i = 0; i < apGainComboBox->getNumItems(); i += 1)
+		for (int i = 0; i < apGainComboBox->getNumItems(); i++)
 		{
-			colors.push_back(Colour(25 * i, 25 * i, 50));
+			colors.emplace_back(Colour(25 * i, 25 * i, 50));
 			legendLabels.add(apGainComboBox->getItemText(i));
 		}
 
-		for (int i = 0; i < colors.size(); i += 1)
+		for (int i = 0; i < colors.size(); i++)
 		{
-			apGainViewRectangles.push_back(std::make_unique<DrawableRectangle>());
+			apGainViewRectangles.emplace_back(std::make_unique<DrawableRectangle>());
 			apGainViewRectangles[i]->setFill(colors[i]);
 			apGainViewRectangles[i]->setRectangle(Rectangle<float>(apGainViewLabels[0]->getX() + 6, apGainViewLabels[i]->getBottom() + 1, 12, 12));
 			apGainViewComponent->addAndMakeVisible(apGainViewRectangles[i].get());
 
-			apGainViewLabels.push_back(std::make_unique<Label>("apGainViewLabel", legendLabels[i]));
+			apGainViewLabels.emplace_back(std::make_unique<Label>("apGainViewLabel", legendLabels[i]));
 			int labelInd = i + 1;
 			apGainViewLabels[labelInd]->setJustificationType(Justification::centredLeft);
 			apGainViewLabels[labelInd]->setFont(FontOptions(fontSize));
@@ -403,7 +403,7 @@ NeuropixV1Interface::NeuropixV1Interface(std::shared_ptr<Neuropixels_1> d, OnixS
 		lfpGainViewComponent = std::make_unique<Component>("lfpGainViewComponent");
 		lfpGainViewComponent->setBounds(enableViewComponent->getX(), enableViewComponent->getY(), 120, 300);
 
-		lfpGainViewLabels.push_back(std::make_unique<Label>("lfpGainViewLabel", "LFP GAIN"));
+		lfpGainViewLabels.emplace_back(std::make_unique<Label>("lfpGainViewLabel", "LFP GAIN"));
 		lfpGainViewLabels[0]->setJustificationType(Justification::centredLeft);
 		lfpGainViewLabels[0]->setFont(FontOptions(fontSize));
 		lfpGainViewLabels[0]->setColour(Label::ColourIds::textColourId, colour);
@@ -413,20 +413,20 @@ NeuropixV1Interface::NeuropixV1Interface(std::shared_ptr<Neuropixels_1> d, OnixS
 		colors.clear();
 		legendLabels.clear();
 
-		for (int i = 0; i < lfpGainComboBox->getNumItems(); i += 1)
+		for (int i = 0; i < lfpGainComboBox->getNumItems(); i++)
 		{
-			colors.push_back(Colour(66, 25 * i, 35 * i));
+			colors.emplace_back(Colour(66, 25 * i, 35 * i));
 			legendLabels.add(lfpGainComboBox->getItemText(i));
 		}
 
-		for (int i = 0; i < colors.size(); i += 1)
+		for (int i = 0; i < colors.size(); i++)
 		{
-			lfpGainViewRectangles.push_back(std::make_unique<DrawableRectangle>());
+			lfpGainViewRectangles.emplace_back(std::make_unique<DrawableRectangle>());
 			lfpGainViewRectangles[i]->setFill(colors[i]);
 			lfpGainViewRectangles[i]->setRectangle(Rectangle<float>(lfpGainViewLabels[0]->getX() + 6, lfpGainViewLabels[i]->getBottom() + 1, 12, 12));
 			lfpGainViewComponent->addAndMakeVisible(lfpGainViewRectangles[i].get());
 
-			lfpGainViewLabels.push_back(std::make_unique<Label>("lfpGainViewLabel", legendLabels[i]));
+			lfpGainViewLabels.emplace_back(std::make_unique<Label>("lfpGainViewLabel", legendLabels[i]));
 			int labelInd = i + 1;
 			lfpGainViewLabels[labelInd]->setJustificationType(Justification::centredLeft);
 			lfpGainViewLabels[labelInd]->setFont(FontOptions(fontSize));
@@ -441,7 +441,7 @@ NeuropixV1Interface::NeuropixV1Interface(std::shared_ptr<Neuropixels_1> d, OnixS
 		referenceViewComponent = std::make_unique<Component>("referenceViewComponent");
 		referenceViewComponent->setBounds(enableViewComponent->getX(), enableViewComponent->getY(), 120, 300);
 
-		referenceViewLabels.push_back(std::make_unique<Label>("referenceViewLabel", "REFERENCE"));
+		referenceViewLabels.emplace_back(std::make_unique<Label>("referenceViewLabel", "REFERENCE"));
 		referenceViewLabels[0]->setJustificationType(Justification::centredLeft);
 		referenceViewLabels[0]->setFont(FontOptions(fontSize));
 		referenceViewLabels[0]->setColour(Label::ColourIds::textColourId, colour);
@@ -451,28 +451,28 @@ NeuropixV1Interface::NeuropixV1Interface(std::shared_ptr<Neuropixels_1> d, OnixS
 		colors.clear();
 		legendLabels.clear();
 
-		for (int i = 0; i < referenceComboBox->getNumItems(); i += 1)
+		for (int i = 0; i < referenceComboBox->getNumItems(); i++)
 		{
 			String ref = referenceComboBox->getItemText(i);
 
 			if (ref.contains("Ext"))
-				colors.push_back(Colours::pink);
+				colors.emplace_back(Colours::pink);
 			else if (ref.contains("Tip"))
-				colors.push_back(Colours::orange);
+				colors.emplace_back(Colours::orange);
 			else
-				colors.push_back(Colours::purple);
+				colors.emplace_back(Colours::purple);
 
 			legendLabels.add(referenceComboBox->getItemText(i));
 		}
 
-		for (int i = 0; i < colors.size(); i += 1)
+		for (int i = 0; i < colors.size(); i++)
 		{
-			referenceViewRectangles.push_back(std::make_unique<DrawableRectangle>());
+			referenceViewRectangles.emplace_back(std::make_unique<DrawableRectangle>());
 			referenceViewRectangles[i]->setFill(colors[i]);
 			referenceViewRectangles[i]->setRectangle(Rectangle<float>(referenceViewLabels[0]->getX() + 6, referenceViewLabels[i]->getBottom() + 1, 12, 12));
 			referenceViewComponent->addAndMakeVisible(referenceViewRectangles[i].get());
 
-			referenceViewLabels.push_back(std::make_unique<Label>("lfpGainViewLabel", legendLabels[i]));
+			referenceViewLabels.emplace_back(std::make_unique<Label>("lfpGainViewLabel", legendLabels[i]));
 			int labelInd = i + 1;
 			referenceViewLabels[labelInd]->setJustificationType(Justification::centredLeft);
 			referenceViewLabels[labelInd]->setFont(FontOptions(fontSize));
@@ -487,7 +487,7 @@ NeuropixV1Interface::NeuropixV1Interface(std::shared_ptr<Neuropixels_1> d, OnixS
 		activityViewComponent = std::make_unique<Component>("activityViewComponent");
 		activityViewComponent->setBounds(enableViewComponent->getX(), enableViewComponent->getY(), 120, 300);
 
-		activityViewLabels.push_back(std::make_unique<Label>("activityViewLabel", "AMPLITUDE"));
+		activityViewLabels.emplace_back(std::make_unique<Label>("activityViewLabel", "AMPLITUDE"));
 		activityViewLabels[0]->setJustificationType(Justification::centredLeft);
 		activityViewLabels[0]->setFont(FontOptions(fontSize));
 		activityViewLabels[0]->setColour(Label::ColourIds::textColourId, colour);
@@ -497,20 +497,20 @@ NeuropixV1Interface::NeuropixV1Interface(std::shared_ptr<Neuropixels_1> d, OnixS
 		colors.clear();
 		legendLabels.clear();
 
-		for (int i = 0; i < 6; i += 1)
+		for (int i = 0; i < 6; i++)
 		{
-			colors.push_back(ColourScheme::getColourForNormalizedValue(float(i) / 5.0f));
+			colors.emplace_back(ColourScheme::getColourForNormalizedValue(float(i) / 5.0f));
 			legendLabels.add(String(float(probeBrowser->maxPeakToPeakAmplitude) / 5.0f * float(i)) + " uV");
 		}
 
-		for (int i = 0; i < colors.size(); i += 1)
+		for (int i = 0; i < colors.size(); i++)
 		{
-			activityViewRectangles.push_back(std::make_unique<DrawableRectangle>());
+			activityViewRectangles.emplace_back(std::make_unique<DrawableRectangle>());
 			activityViewRectangles[i]->setFill(colors[i]);
 			activityViewRectangles[i]->setRectangle(Rectangle<float>(activityViewLabels[0]->getX() + 6, activityViewLabels[i]->getBottom() + 1, 12, 12));
 			activityViewComponent->addAndMakeVisible(activityViewRectangles[i].get());
 
-			activityViewLabels.push_back(std::make_unique<Label>("activityViewLabel", legendLabels[i]));
+			activityViewLabels.emplace_back(std::make_unique<Label>("activityViewLabel", legendLabels[i]));
 			int labelInd = i + 1;
 			activityViewLabels[labelInd]->setJustificationType(Justification::centredLeft);
 			activityViewLabels[labelInd]->setFont(FontOptions(fontSize));
@@ -643,12 +643,12 @@ void NeuropixV1Interface::checkForExistingChannelPreset()
 	std::set<Bank> uniqueBanks;
 	std::vector<ElectrodeMetadata> electrodes;
 
-	for (int i = 0; i < npx->settings->electrodeMetadata.size(); i += 1)
+	for (int i = 0; i < npx->settings->electrodeMetadata.size(); i++)
 	{
 		if (npx->settings->electrodeMetadata[i].status == ElectrodeStatus::CONNECTED)
 		{
 			uniqueBanks.insert(npx->settings->electrodeMetadata[i].bank);
-			electrodes.push_back(npx->settings->electrodeMetadata[i]);
+			electrodes.emplace_back(npx->settings->electrodeMetadata[i]);
 		}
 	}
 
@@ -667,7 +667,7 @@ void NeuropixV1Interface::checkForExistingChannelPreset()
 	{
 		bool isBankC = true, isSingleColumn = true, isTetrode = true;
 
-		for (int i = 0; i < electrodes.size(); i += 1)
+		for (int i = 0; i < electrodes.size(); i++)
 		{
 			if (electrodes[i].global_index < 576 || electrodes[i].global_index >= 960)
 			{
@@ -779,7 +779,7 @@ void NeuropixV1Interface::buttonClicked(Button* button)
 		drawLegend();
 		repaint();
 	}
-	else if (button == selectElctrodeButton.get())
+	else if (button == selectElectrodeButton.get())
 	{
 		Array<int> selection = getSelectedElectrodes();
 
@@ -935,8 +935,8 @@ void NeuropixV1Interface::setInterfaceEnabledState(bool enabledState)
 	if (probeEnableButton != nullptr)
 		probeEnableButton->setEnabled(enabledState);
 
-	if (selectElctrodeButton != nullptr)
-		selectElctrodeButton->setEnabled(enabledState);
+	if (selectElectrodeButton != nullptr)
+		selectElectrodeButton->setEnabled(enabledState);
 
 	if (electrodeConfigurationComboBox != nullptr)
 		electrodeConfigurationComboBox->setEnabled(enabledState);

--- a/Source/UI/NeuropixV1Interface.h
+++ b/Source/UI/NeuropixV1Interface.h
@@ -96,7 +96,6 @@ private:
 
 	bool acquisitionIsActive = false;
 
-	// Combo box - probe-specific settings
 	std::unique_ptr<ComboBox> electrodeConfigurationComboBox;
 	std::unique_ptr<ComboBox> lfpGainComboBox;
 	std::unique_ptr<ComboBox> apGainComboBox;
@@ -104,7 +103,6 @@ private:
 	std::unique_ptr<ComboBox> filterComboBox;
 	std::unique_ptr<ComboBox> activityViewComboBox;
 
-	// LABELS
 	std::unique_ptr<Label> nameLabel;
 	std::unique_ptr<Label> infoLabel;
 	std::unique_ptr<Label> lfpGainLabel;
@@ -118,9 +116,8 @@ private:
 	std::unique_ptr<Label> adcCalibrationFileLabel;
 	std::unique_ptr<Label> gainCalibrationFileLabel;
 
-	// BUTTONS
 	std::unique_ptr<UtilityButton> probeEnableButton;
-	std::unique_ptr<UtilityButton> enableButton;
+	std::unique_ptr<UtilityButton> selectElctrodeButton;
 
 	std::unique_ptr<UtilityButton> enableViewButton;
 	std::unique_ptr<UtilityButton> lfpGainViewButton;
@@ -129,6 +126,8 @@ private:
 	std::unique_ptr<UtilityButton> bankViewButton;
 	std::unique_ptr<UtilityButton> activityViewButton;
 
+	std::unique_ptr<DrawableRectangle> probeInterfaceRectangle;
+	std::unique_ptr<Label> probeInterfaceLabel;
 	std::unique_ptr<UtilityButton> loadJsonButton;
 	std::unique_ptr<UtilityButton> saveJsonButton;
 
@@ -142,6 +141,8 @@ private:
 	std::unique_ptr<FileChooser> gainCalibrationFileChooser;
 
 	std::unique_ptr<ProbeBrowser> probeBrowser;
+
+	std::unique_ptr<ToggleButton> offsetCorrectionCheckbox;
 
 	std::unique_ptr<Component> enableViewComponent;
 	std::unique_ptr<Component> apGainViewComponent;

--- a/Source/UI/NeuropixV1Interface.h
+++ b/Source/UI/NeuropixV1Interface.h
@@ -117,7 +117,7 @@ private:
 	std::unique_ptr<Label> gainCalibrationFileLabel;
 
 	std::unique_ptr<UtilityButton> probeEnableButton;
-	std::unique_ptr<UtilityButton> selectElctrodeButton;
+	std::unique_ptr<UtilityButton> selectElectrodeButton;
 
 	std::unique_ptr<UtilityButton> enableViewButton;
 	std::unique_ptr<UtilityButton> lfpGainViewButton;


### PR DESCRIPTION
As discussed in #25, there is a slight but consistent offset that occurs in all AP and LFP channels. 

With this PR, the plugin will wait ~5 seconds before taking 100 consecutive samples and calculating a mean value to use as the offset value. All samples after this 5 second wait will be offset-corrected.

This also provides minor updates to the error messages that are given to the user when the context is not initialized properly, and also respects any calibration file paths that are set in the canvas before the hardware is connected.

Fixes #25 