### PR TITLE
Combine BNO data streams

### DIFF
--- a/Source/Devices/Bno055.cpp
+++ b/Source/Devices/Bno055.cpp
@@ -28,59 +28,69 @@ Bno055::Bno055(String name, const oni_dev_idx_t deviceIdx_, std::shared_ptr<Onix
 {
 	const float bitVolts = 1.0;
 
-	StreamInfo eulerAngleStream;
-	eulerAngleStream.name = name + "-Euler";
-	eulerAngleStream.description = "Bosch Bno055 9-axis inertial measurement unit (IMU) Euler angle";
-	eulerAngleStream.identifier = "onix-bno055.data.euler";
-	eulerAngleStream.numChannels = 3;
-	eulerAngleStream.sampleRate = 100.0f;
-	eulerAngleStream.channelPrefix = "Euler";
-	eulerAngleStream.bitVolts = bitVolts;
-	eulerAngleStream.channelType = ContinuousChannel::Type::AUX;
+	StreamInfo eulerAngleStream = StreamInfo(
+		name + "-Euler",
+		"Bosch Bno055 9-axis inertial measurement unit (IMU) Euler angle",
+		"onix-bno055.data.euler",
+		3,
+		sampleRate,
+		"Euler",
+		ContinuousChannel::Type::AUX,
+		bitVolts,
+		"Degrees",
+		{ "Yaw", "Roll", "Pitch" });
 	streams.add(eulerAngleStream);
 
-	StreamInfo quaternionStream;
-	quaternionStream.name = name + "-Quaternion";
-	quaternionStream.description = "Bosch Bno055 9-axis inertial measurement unit (IMU) Quaternion";
-	quaternionStream.identifier = "onix-bno055.data.quat";
-	quaternionStream.numChannels = 4;
-	quaternionStream.sampleRate = 100.0f;
-	quaternionStream.channelPrefix = "Quaternion";
-	quaternionStream.bitVolts = bitVolts;
-	quaternionStream.channelType = ContinuousChannel::Type::AUX;
+	StreamInfo quaternionStream = StreamInfo(
+		name + "-Quaternion",
+		"Bosch Bno055 9-axis inertial measurement unit (IMU) Quaternion",
+		"onix-bno055.data.quat",
+		4,
+		sampleRate,
+		"Quaternion",
+		ContinuousChannel::Type::AUX,
+		bitVolts,
+		"",
+		{ "W", "X", "Y", "Z" });
 	streams.add(quaternionStream);
 
-	StreamInfo accelerationStream;
-	accelerationStream.name = name + "-Acceleration";
-	accelerationStream.description = "Bosch Bno055 9-axis inertial measurement unit (IMU) Acceleration";
-	accelerationStream.identifier = "onix-bno055.data.acc";
-	accelerationStream.numChannels = 3;
-	accelerationStream.sampleRate = 100.0f;
-	accelerationStream.channelPrefix = "Acceleration";
-	accelerationStream.bitVolts = bitVolts;
-	accelerationStream.channelType = ContinuousChannel::Type::AUX;
+	StreamInfo accelerationStream = StreamInfo(
+		name + "-Acceleration",
+		"Bosch Bno055 9-axis inertial measurement unit (IMU) Acceleration",
+		"onix-bno055.data.acc",
+		3,
+		sampleRate,
+		"Acceleration",
+		ContinuousChannel::Type::AUX,
+		bitVolts,
+		"m / s ^ 2",
+		{ "X", "Y", "Z" });
 	streams.add(accelerationStream);
 
-	StreamInfo gravityStream;
-	gravityStream.name = name + "-Gravity";
-	gravityStream.description = "Bosch Bno055 9-axis inertial measurement unit (IMU) Gravity";
-	gravityStream.identifier = "onix-bno055.data.grav";
-	gravityStream.numChannels = 3;
-	gravityStream.sampleRate = 100.0f;
-	gravityStream.channelPrefix = "Gravity";
-	gravityStream.bitVolts = bitVolts;
-	gravityStream.channelType = ContinuousChannel::Type::AUX;
+	StreamInfo gravityStream = StreamInfo(
+		name + "-Gravity",
+		"Bosch Bno055 9-axis inertial measurement unit (IMU) Gravity",
+		"onix-bno055.data.grav",
+		3,
+		sampleRate,
+		"Gravity",
+		ContinuousChannel::Type::AUX,
+		bitVolts,
+		"m/s^2",
+		{ "X", "Y", "Z" });
 	streams.add(gravityStream);
 
-	StreamInfo temperatureStream;
-	temperatureStream.name = name + "-Temperature";
-	temperatureStream.description = "Bosch Bno055 9-axis inertial measurement unit (IMU) Temperature";
-	temperatureStream.identifier = "onix-bno055.data.temp";
-	temperatureStream.numChannels = 1;
-	temperatureStream.sampleRate = 100.0f;
-	temperatureStream.channelPrefix = "Temperature";
-	temperatureStream.bitVolts = bitVolts;
-	temperatureStream.channelType = ContinuousChannel::Type::AUX;
+	StreamInfo temperatureStream = StreamInfo(
+		name + "-Temperature",
+		"Bosch Bno055 9-axis inertial measurement unit (IMU) Temperature",
+		"onix-bno055.data.temp",
+		1,
+		sampleRate,
+		"Temperature",
+		ContinuousChannel::Type::AUX,
+		bitVolts,
+		"Celsius",
+		{ "" });
 	streams.add(temperatureStream);
 
 	for (int i = 0; i < numFrames; i++)
@@ -131,21 +141,9 @@ void Bno055::addFrame(oni_frame_t* frame)
 
 void Bno055::addSourceBuffers(OwnedArray<DataBuffer>& sourceBuffers)
 {
-	for (StreamInfo streamInfo : streams)
-	{
-		sourceBuffers.add(new DataBuffer(streamInfo.numChannels, (int)streamInfo.sampleRate * bufferSizeInSeconds));
+	sourceBuffers.add(new DataBuffer(numberOfChannels, (int)sampleRate * bufferSizeInSeconds));
 
-		if (streamInfo.channelPrefix.equalsIgnoreCase("Euler"))
-			eulerBuffer = sourceBuffers.getLast();
-		else if (streamInfo.channelPrefix.equalsIgnoreCase("Quaternion"))
-			quaternionBuffer = sourceBuffers.getLast();
-		else if (streamInfo.channelPrefix.equalsIgnoreCase("Acceleration"))
-			accelerationBuffer = sourceBuffers.getLast();
-		else if (streamInfo.channelPrefix.equalsIgnoreCase("Gravity"))
-			gravityBuffer = sourceBuffers.getLast();
-		else if (streamInfo.channelPrefix.equalsIgnoreCase("Temperature"))
-			temperatureBuffer = sourceBuffers.getLast();
-	}
+	bnoBuffer = sourceBuffers.getLast();
 }
 
 void Bno055::processFrames()
@@ -165,31 +163,42 @@ void Bno055::processFrames()
 		const float quaternionScale = 1.0f / (1 << 14); // 1 = 2^14 LSB
 		const float accelerationScale = 1.0f / 100; // 1m / s^2 = 100 LSB
 
+		int channelOffset = 0;
+
+		// Euler
 		for (int i = 0; i < 3; i++)
 		{
-			eulerSamples[currentFrame + i * numFrames] = float(*(dataPtr + dataOffset)) * eulerAngleScale;
+			bnoSamples[currentFrame + channelOffset * numFrames] = float(*(dataPtr + dataOffset)) * eulerAngleScale;
 			dataOffset++;
+			channelOffset += 1;
 		}
 
+		// Quaternion
 		for (int i = 0; i < 4; i++)
 		{
-			quaternionSamples[currentFrame + i * numFrames] = float(*(dataPtr + dataOffset)) * quaternionScale;
+			bnoSamples[currentFrame + channelOffset * numFrames] = float(*(dataPtr + dataOffset)) * quaternionScale;
 			dataOffset++;
+			channelOffset += 1;
 		}
 
+		// Acceleration
 		for (int i = 0; i < 3; i++)
 		{
-			accelerationSamples[currentFrame + i * numFrames] = float(*(dataPtr + dataOffset)) * accelerationScale;
+			bnoSamples[currentFrame + channelOffset * numFrames] = float(*(dataPtr + dataOffset)) * accelerationScale;
 			dataOffset++;
+			channelOffset += 1;
 		}
 
+		// Gravity
 		for (int i = 0; i < 3; i++)
 		{
-			gravitySamples[currentFrame + i * numFrames] = float(*(dataPtr + dataOffset)) * accelerationScale;
+			bnoSamples[currentFrame + channelOffset * numFrames] = float(*(dataPtr + dataOffset)) * accelerationScale;
 			dataOffset++;
+			channelOffset += 1;
 		}
 
-		temperatureSamples[currentFrame] = float(*((uint8_t*)(dataPtr + dataOffset)));
+		// Temperature
+		bnoSamples[currentFrame + channelOffset * numFrames] = float(*((uint8_t*)(dataPtr + dataOffset)));
 
 		oni_destroy_frame(frame);
 
@@ -206,11 +215,7 @@ void Bno055::processFrames()
 		if (shouldAddToBuffer)
 		{
 			shouldAddToBuffer = false;
-			eulerBuffer->addToBuffer(eulerSamples, sampleNumbers, bnoTimestamps, eventCodes, numFrames);
-			quaternionBuffer->addToBuffer(quaternionSamples, sampleNumbers, bnoTimestamps, eventCodes, numFrames);
-			accelerationBuffer->addToBuffer(accelerationSamples, sampleNumbers, bnoTimestamps, eventCodes, numFrames);
-			gravityBuffer->addToBuffer(gravitySamples, sampleNumbers, bnoTimestamps, eventCodes, numFrames);
-			temperatureBuffer->addToBuffer(temperatureSamples, sampleNumbers, bnoTimestamps, eventCodes, numFrames);
+			bnoBuffer->addToBuffer(bnoSamples, sampleNumbers, bnoTimestamps, eventCodes, numFrames);
 		}
 	}
 }

--- a/Source/Devices/Bno055.h
+++ b/Source/Devices/Bno055.h
@@ -60,11 +60,7 @@ public:
 
 private:
 
-	DataBuffer* eulerBuffer;
-	DataBuffer* quaternionBuffer;
-	DataBuffer* accelerationBuffer;
-	DataBuffer* gravityBuffer;
-	DataBuffer* temperatureBuffer;
+	DataBuffer* bnoBuffer;
 
 	static const int numFrames = 2;
 
@@ -72,11 +68,10 @@ private:
 
 	bool shouldAddToBuffer = false;
 
-	float eulerSamples[3 * numFrames];
-	float quaternionSamples[4 * numFrames];
-	float accelerationSamples[3 * numFrames];
-	float gravitySamples[3 * numFrames];
-	float temperatureSamples[numFrames];
+	static const int numberOfChannels = 3 + 3 + 4 + 3 + 1;
+	static constexpr float sampleRate = 100.0f;
+
+	float bnoSamples[numberOfChannels * numFrames];
 
 	double bnoTimestamps[numFrames];
 	int64 sampleNumbers[numFrames];

--- a/Source/Devices/Neuropixels2e.cpp
+++ b/Source/Devices/Neuropixels2e.cpp
@@ -7,15 +7,17 @@ Neuropixels2e::Neuropixels2e(String name, const oni_dev_idx_t deviceIdx_, std::s
 
 void Neuropixels2e::createDataStream(int n)
 {
-	StreamInfo apStream;
-	apStream.name = getName()+"-"+String(n);
-	apStream.description = "Neuropixels 2.0 data stream";
-	apStream.identifier = "onix-neuropixels2.data";
-	apStream.numChannels = 384;
-	apStream.sampleRate = 30000.0f;
-	apStream.channelPrefix = "CH";
-	apStream.bitVolts = 0.195f;
-	apStream.channelType = ContinuousChannel::Type::ELECTRODE;
+	StreamInfo apStream = StreamInfo(
+		getName() + "-" + String(n),
+		"Neuropixels 2.0 data stream",
+		"onix-neuropixels2.data",
+		384,
+		30000.0f,
+		"CH",
+		ContinuousChannel::Type::ELECTRODE,
+		0.195f,
+		CharPointer_UTF8("\xc2\xb5V"),
+		{});
 	streams.add(apStream);
 }
 
@@ -213,9 +215,9 @@ void Neuropixels2e::addFrame(oni_frame_t* frame)
 void Neuropixels2e::addSourceBuffers(OwnedArray<DataBuffer>& sourceBuffers)
 {
 	int bufferIdx = 0;
-	for (StreamInfo streamInfo : streams)
+	for (const auto& streamInfo : streams)
 	{
-		sourceBuffers.add(new DataBuffer(streamInfo.numChannels, (int)streamInfo.sampleRate * bufferSizeInSeconds));
+		sourceBuffers.add(new DataBuffer(streamInfo.getNumChannels(), (int)streamInfo.getSampleRate() * bufferSizeInSeconds));
 		apBuffer[bufferIdx++] = sourceBuffers.getLast();
 	}
 }

--- a/Source/Devices/Neuropixels_1.cpp
+++ b/Source/Devices/Neuropixels_1.cpp
@@ -178,26 +178,30 @@ Neuropixels_1::Neuropixels_1(String name, const oni_dev_idx_t deviceIdx_, std::s
 	OnixDevice("Neuropixels 1.0 " + name, OnixDeviceType::NEUROPIXELS_1, deviceIdx_, ctx_),
 	I2CRegisterContext(ProbeI2CAddress, deviceIdx_, ctx_)
 {
-	StreamInfo apStream;
-	apStream.name = name + "-AP";
-	apStream.description = "Neuropixels 1.0 AP band data stream";
-	apStream.identifier = "onix-neuropixels1.data.ap";
-	apStream.numChannels = 384;
-	apStream.sampleRate = 30000.0f;
-	apStream.channelPrefix = "AP";
-	apStream.bitVolts = 0.195f;
-	apStream.channelType = ContinuousChannel::Type::ELECTRODE;
+	StreamInfo apStream = StreamInfo(
+		name + "-AP",
+		"Neuropixels 1.0 AP band data stream",
+		"onix-neuropixels1.data.ap",
+		384,
+		30000.0f,
+		"AP",
+		ContinuousChannel::Type::ELECTRODE,
+		0.195f,
+		CharPointer_UTF8("\xc2\xb5V"),
+		{});
 	streams.add(apStream);
 
-	StreamInfo lfpStream;
-	lfpStream.name = name + "-LFP";
-	lfpStream.description = "Neuropixels 1.0 LFP band data stream";
-	lfpStream.identifier = "onix-neuropixels1.data.lfp";
-	lfpStream.numChannels = 384;
-	lfpStream.sampleRate = 2500.0f;
-	lfpStream.channelPrefix = "LFP";
-	lfpStream.bitVolts = 0.195f;
-	lfpStream.channelType = ContinuousChannel::Type::ELECTRODE;
+	StreamInfo lfpStream = StreamInfo(
+		name + "-LFP",
+		"Neuropixels 1.0 LFP band data stream",
+		"onix-neuropixels1.data.lfp",
+		384,
+		2500.0f,
+		"LFP",
+		ContinuousChannel::Type::ELECTRODE,
+		0.195f,
+		CharPointer_UTF8("\xc2\xb5V"),
+		{});
 	streams.add(lfpStream);
 
 	settings = std::make_unique<ProbeSettings>();
@@ -410,11 +414,11 @@ void Neuropixels_1::addSourceBuffers(OwnedArray<DataBuffer>& sourceBuffers)
 {
 	for (StreamInfo streamInfo : streams)
 	{
-		sourceBuffers.add(new DataBuffer(streamInfo.numChannels, (int)streamInfo.sampleRate * bufferSizeInSeconds));
+		sourceBuffers.add(new DataBuffer(streamInfo.getNumChannels(), (int)streamInfo.getSampleRate() * bufferSizeInSeconds));
 
-		if (streamInfo.channelPrefix.equalsIgnoreCase("AP"))
+		if (streamInfo.getChannelPrefix().equalsIgnoreCase("AP"))
 			apBuffer = sourceBuffers.getLast();
-		else if (streamInfo.channelPrefix.equalsIgnoreCase("LFP"))
+		else if (streamInfo.getChannelPrefix().equalsIgnoreCase("LFP"))
 			lfpBuffer = sourceBuffers.getLast();
 	}
 }

--- a/Source/OnixDevice.h
+++ b/Source/OnixDevice.h
@@ -53,14 +53,70 @@ enum class OnixDeviceType {
 };
 
 struct StreamInfo {
-	String name;
-	String description;
-	String identifier;
-	int numChannels;
-	float sampleRate;
-	String channelPrefix;
-	ContinuousChannel::Type channelType;
-	float bitVolts;
+public:
+	StreamInfo()
+	{
+		name_ = "name";
+		description_ = "description";
+		identifier_ = "identifier";
+		numChannels_ = 0;
+		sampleRate_ = 0;
+		channelPrefix_ = "channelPrefix";
+		channelType_ = ContinuousChannel::Type::INVALID;
+		bitVolts_ = 1.0f;
+		units_ = "units";
+		suffixes_ = { "suffixes" };
+	}
+
+	StreamInfo(String name, String description, String identifier, int numChannels, float sampleRate, String channelPrefix, ContinuousChannel::Type channelType,
+		float bitVolts, String units, StringArray suffixes)
+	{
+		name_ = name;
+		description_ = description;
+		identifier_ = identifier;
+		numChannels_ = numChannels;
+		sampleRate_ = sampleRate;
+		channelPrefix_ = channelPrefix;
+		channelType_ = channelType;
+		bitVolts_ = bitVolts;
+		units_ = units;
+		suffixes_ = suffixes;
+
+		if (numChannels_ != suffixes_.size())
+		{
+			LOGE("Difference between number of channels and suffixes. Generating default suffixes instead.");
+			suffixes_.clear();
+			suffixes_.ensureStorageAllocated(numChannels);
+			
+			for (int i = 0; i < numChannels_; i += 1)
+			{
+				suffixes_.add(String(i + 1));
+			}
+		}
+	};
+
+	String getName() const { return name_; }
+	String getDescription() const { return description_; }
+	String getIdentifer() const { return identifier_; }
+	int getNumChannels() const { return numChannels_; }
+	float getSampleRate() const { return sampleRate_; }
+	String getChannelPrefix() const { return channelPrefix_; }
+	ContinuousChannel::Type getChannelType() const { return channelType_; }
+	float getBitVolts() const { return bitVolts_; }
+	String getUnits() const { return units_; }
+	StringArray getSuffixes() const { return suffixes_; }
+
+private:
+	String name_;
+	String description_;
+	String identifier_;
+	int numChannels_;
+	float sampleRate_;
+	String channelPrefix_;
+	ContinuousChannel::Type channelType_;
+	float bitVolts_;
+	String units_;
+	StringArray suffixes_;
 };
 
 /**

--- a/Source/OnixSource.h
+++ b/Source/OnixSource.h
@@ -135,6 +135,10 @@ private:
 
 	bool devicesFound = false;
 
+	void addIndividualStreams(Array<StreamInfo>, OwnedArray<DataStream>*, OwnedArray<DeviceInfo>*, OwnedArray<ContinuousChannel>*);
+
+	void addCombinedStreams(DataStream::Settings, Array<StreamInfo>, OwnedArray<DataStream>*, OwnedArray<DeviceInfo>*, OwnedArray<ContinuousChannel>*);
+
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OnixSource);
 };
 


### PR DESCRIPTION
This PR combines the previously separate BNO data streams into one stream. The names of each channel are maintained so that it is easy to see which channel corresponds to which data type.

Also, I updated the `StreamInfo` struct to hold units, and now the channels are all set with the correct units. Even though the LFP viewer does not currently respect these, future changes should allow it to read the different units per channel and write them to the viewer.

Fixes #31 