### PR TITLE
Load and save configuration settings

### DIFF
--- a/Source/Devices/AnalogIO.cpp
+++ b/Source/Devices/AnalogIO.cpp
@@ -165,7 +165,7 @@ void AnalogIO::processFrames()
 
 			currentAverageFrame = 0;
 
-			timestamps[currentFrame] = frame->time;
+			timestamps[currentFrame] = deviceContext->convertTimestampToSeconds(frame->time);
 			sampleNumbers[currentFrame] = sampleNumber++;
 
 			currentFrame++;

--- a/Source/Devices/AnalogIO.h
+++ b/Source/Devices/AnalogIO.h
@@ -99,6 +99,19 @@ public:
 		return channelDirection[channelNumber];
 	}
 
+	static String getChannelDirection(AnalogIODirection direction)
+	{
+		switch (direction)
+		{
+		case AnalogIODirection::Input:
+			return "Input";
+		case AnalogIODirection::Output:
+			return "Output";
+		default:
+			return "";
+		}
+	}
+
 	void setChannelDirection(int channelNumber, AnalogIODirection direction)
 	{
 		if (channelNumber > numChannels || channelNumber < 0)
@@ -121,20 +134,7 @@ public:
 		return channelVoltageRange[channelNumber];
 	}
 
-	void setChannelVoltageRange(int channelNumber, AnalogIOVoltageRange direction)
-	{
-		if (channelNumber > numChannels || channelNumber < 0)
-		{
-			LOGE("Channel number must be between 0 and " + String(channelNumber));
-			return;
-		}
-
-		channelVoltageRange[channelNumber] = direction;
-	}
-
 	AnalogIODataType getDataType() const { return dataType; }
-
-	void setDataType(AnalogIODataType type) { dataType = type; }
 
 	int getNumChannels() { return numChannels; }
 
@@ -173,6 +173,19 @@ private:
 	std::array<float, numChannels> voltsPerDivision;
 
 	static float getVoltsPerDivision(AnalogIOVoltageRange voltageRange);
+
+	void setChannelVoltageRange(int channelNumber, AnalogIOVoltageRange direction)
+	{
+		if (channelNumber > numChannels || channelNumber < 0)
+		{
+			LOGE("Channel number must be between 0 and " + String(channelNumber));
+			return;
+		}
+
+		channelVoltageRange[channelNumber] = direction;
+	}
+
+	void setDataType(AnalogIODataType type) { dataType = type; }
 
 	JUCE_LEAK_DETECTOR(AnalogIO);
 };

--- a/Source/Devices/Bno055.cpp
+++ b/Source/Devices/Bno055.cpp
@@ -151,7 +151,7 @@ void Bno055::processFrames()
 
 		int16_t* dataPtr = (int16_t*)frame->data;
 
-		bnoTimestamps[currentFrame] = frame->time;
+		bnoTimestamps[currentFrame] = deviceContext->convertTimestampToSeconds(frame->time);
 
 		int dataOffset = 4;
 

--- a/Source/Devices/DigitalIO.cpp
+++ b/Source/Devices/DigitalIO.cpp
@@ -82,7 +82,7 @@ void DigitalIO::processFrames()
 		oni_frame_t* frame = frameArray.removeAndReturn(0);
 
 		uint16_t* dataPtr = (uint16_t*)frame->data;
-		uint64_t timestamp = frame->time;
+		uint64_t timestamp = deviceContext->convertTimestampToSeconds(frame->time);
 
 		int dataOffset = 4;
 

--- a/Source/Devices/HarpSyncInput.cpp
+++ b/Source/Devices/HarpSyncInput.cpp
@@ -97,7 +97,7 @@ void HarpSyncInput::processFrames()
 
 		uint32_t* dataPtr = (uint32_t*)frame->data;
 
-		timestamps[currentFrame] = frame->time;
+		timestamps[currentFrame] = deviceContext->convertTimestampToSeconds(frame->time);
 
 		harpTimeSamples[currentFrame] = *(dataPtr + 2) + 1;
 

--- a/Source/Devices/MemoryMonitor.cpp
+++ b/Source/Devices/MemoryMonitor.cpp
@@ -147,9 +147,8 @@ void MemoryMonitor::processFrames()
 		oni_frame_t* frame = frameArray.removeAndReturn(0);
 
 		uint32_t* dataPtr = (uint32_t*)frame->data;
-		uint64_t timestamp = frame->time;
 
-		timestamps[currentFrame] = frame->time;
+		timestamps[currentFrame] = deviceContext->convertTimestampToSeconds(frame->time);
 
 		percentUsedSamples[currentFrame] = 100.0f * float(*(dataPtr + 2)) / totalMemory;
 

--- a/Source/Devices/Neuropixels2e.cpp
+++ b/Source/Devices/Neuropixels2e.cpp
@@ -621,7 +621,7 @@ void Neuropixels2e::processFrames()
 		uint16_t* amplifierData = dataPtr + 9;
 
 		sampleNumbers[frameCount] = sampleNumber;
-		timestamps[frameCount] = frame->time;
+		timestamps[frameCount] = deviceContext->convertTimestampToSeconds(frame->time);
 
 		for (int i = 0; i < FramesPerSuperFrame; i++)
 		{

--- a/Source/Devices/Neuropixels_1.cpp
+++ b/Source/Devices/Neuropixels_1.cpp
@@ -472,7 +472,7 @@ void Neuropixels_1::processFrames()
 
 		uint16_t* dataPtr = (uint16_t*)frame->data;
 
-		apTimestamps[superFrameCount] = frame->time;
+		apTimestamps[superFrameCount] = deviceContext->convertTimestampToSeconds(frame->time);
 		apSampleNumbers[superFrameCount] = apSampleNumber++;
 
 		for (int i = 0; i < framesPerSuperFrame; i++)

--- a/Source/Devices/OutputClock.h
+++ b/Source/Devices/OutputClock.h
@@ -62,17 +62,17 @@ public:
 
 	void processFrames() override {};
 
-	float getFrequencyHz() const { return frequencyHz; }
+	double getFrequencyHz() const { return frequencyHz; }
 
-	void setFrequencyHz(float frequency) { frequencyHz = frequency; }
+	void setFrequencyHz(double frequency) { frequencyHz = frequency; }
 
-	uint32_t getDutyCycle() const { return dutyCycle; }
+	int32_t getDutyCycle() const { return dutyCycle; }
 
-	void setDutyCycle(uint32_t dutyCycle_) { dutyCycle = dutyCycle_; }
+	void setDutyCycle(int32_t dutyCycle_) { dutyCycle = dutyCycle_; }
 
-	uint32_t getDelay() const { return delay; }
+	int32_t getDelay() const { return delay; }
 
-	void setDelay(uint32_t delay_) { delay = delay_; }
+	void setDelay(int32_t delay_) { delay = delay_; }
 
 	bool getGateRun() const { return gateRun; }
 
@@ -85,8 +85,8 @@ public:
 private:
 
 	double frequencyHz = 1e6;
-	uint32_t dutyCycle = 50;
-	uint32_t delay = 0;
+	int32_t dutyCycle = 50;
+	int32_t delay = 0;
 
 	bool gateRun = true;
 

--- a/Source/Devices/PolledBno055.cpp
+++ b/Source/Devices/PolledBno055.cpp
@@ -261,7 +261,7 @@ void PolledBno055::hiResTimerCallback()
 	rc = (uint64_t)deviceContext->readRegister(deviceIdx, DS90UB9x::LASTI2CH, &timestampH);
 	if (rc != ONI_ESUCCESS) return;
 
-	bnoTimestamps[currentFrame] = (uint64_t(timestampH) << 32) | uint64_t(timestampL);
+	bnoTimestamps[currentFrame] = deviceContext->convertTimestampToSeconds((uint64_t(timestampH) << 32) | uint64_t(timestampL));
 
 	sampleNumbers[currentFrame] = sampleNumber++;
 

--- a/Source/Onix1.cpp
+++ b/Source/Onix1.cpp
@@ -35,6 +35,10 @@ Onix1::Onix1(int hostIndex)
 		throw error_t(rc);
 
 	oni_version(&major, &minor, &patch);
+
+	rc = getOption(ONI_OPT_ACQCLKHZ, &ACQ_CLK_HZ);
+	if (rc != ONI_ESUCCESS)
+		throw error_t(rc);
 }
 
 Onix1::~Onix1()

--- a/Source/Onix1.h
+++ b/Source/Onix1.h
@@ -88,7 +88,7 @@ public:
 
 	int issueReset() { int val = 1; int rc = setOption(ONI_OPT_RESET, val); return rc; }
 
-	String getVersion() { return String(major) + "." + String(minor) + "." + String(patch); }
+	std::string getVersion() const { return std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch); }
 
 	double convertTimestampToSeconds(uint32_t timestamp) const { return static_cast<double>(timestamp) / ACQ_CLK_HZ; }
 

--- a/Source/Onix1.h
+++ b/Source/Onix1.h
@@ -90,6 +90,8 @@ public:
 
 	String getVersion() { return String(major) + "." + String(minor) + "." + String(patch); }
 
+	double convertTimestampToSeconds(uint32_t timestamp) const { return static_cast<double>(timestamp) / ACQ_CLK_HZ; }
+
 private:
 
 	/** The ONI ctx object */
@@ -98,6 +100,8 @@ private:
 	int major;
 	int minor;
 	int patch;
+
+	uint32_t ACQ_CLK_HZ;
 
 	device_map_t deviceTable;
 

--- a/Source/OnixSourceCanvas.cpp
+++ b/Source/OnixSourceCanvas.cpp
@@ -208,7 +208,7 @@ void OnixSourceCanvas::updateSettingsInterfaceDataSource(std::shared_ptr<OnixDev
 	else if (device->type == OnixDeviceType::NEUROPIXELSV2E)
 	{
 		auto npx2Found = std::static_pointer_cast<Neuropixels2e>(device);
-		auto npx2Selected = std::static_pointer_cast<Neuropixels2e>(device);
+		auto npx2Selected = std::static_pointer_cast<Neuropixels2e>(selectedDevice);
 		npx2Found->setSettings(npx2Selected->settings[0].get(), 0);
 		npx2Found->setSettings(npx2Selected->settings[1].get(), 1);
 		npx2Found->setGainCorrectionFile(0, npx2Selected->getGainCorrectionFile(0));

--- a/Source/OnixSourceCanvas.cpp
+++ b/Source/OnixSourceCanvas.cpp
@@ -532,12 +532,12 @@ void OnixSourceCanvas::stopAcquisition()
 
 void OnixSourceCanvas::saveCustomParametersToXml(XmlElement* xml)
 {
-	//for (int i = 0; i < settingsInterfaces.size(); i++)
-	//	settingsInterfaces[i]->saveParameters(xml);
+	for (int i = 0; i < settingsInterfaces.size(); i++)
+		settingsInterfaces[i]->saveParameters(xml);
 }
 
 void OnixSourceCanvas::loadCustomParametersFromXml(XmlElement* xml)
 {
-	//for (int i = 0; i < settingsInterfaces.size(); i++)
-	//	settingsInterfaces[i]->loadParameters(xml);
+	for (int i = 0; i < settingsInterfaces.size(); i++)
+		settingsInterfaces[i]->loadParameters(xml);
 }

--- a/Source/OnixSourceCanvas.cpp
+++ b/Source/OnixSourceCanvas.cpp
@@ -158,8 +158,10 @@ void OnixSourceCanvas::updateSettingsInterfaceDataSource(std::shared_ptr<OnixDev
 
 	for (int j = 0; j < settingsInterfaces.size(); j++)
 	{
-		if (device->getDeviceIdx() == settingsInterfaces[j]->device->getDeviceIdx() &&
-			compareDeviceNames(device->getName(), settingsInterfaces[j]->device->getName()))
+		auto selectedDevice = settingsInterfaces[j]->getDevice();
+
+		if (device->getDeviceIdx() == selectedDevice->getDeviceIdx() &&
+			compareDeviceNames(device->getName(), selectedDevice->getName()))
 		{
 			ind = j;
 			break;
@@ -174,10 +176,12 @@ void OnixSourceCanvas::updateSettingsInterfaceDataSource(std::shared_ptr<OnixDev
 		return;
 	}
 
+	auto selectedDevice = settingsInterfaces[ind]->getDevice();
+
 	if (device->type == OnixDeviceType::NEUROPIXELS_1)
 	{
 		auto npx1Found = std::static_pointer_cast<Neuropixels_1>(device);
-		auto npx1Selected = std::static_pointer_cast<Neuropixels_1>(settingsInterfaces[ind]->device);
+		auto npx1Selected = std::static_pointer_cast<Neuropixels_1>(selectedDevice);
 		npx1Found->setSettings(npx1Selected->settings[0].get());
 		npx1Found->adcCalibrationFilePath = npx1Selected->adcCalibrationFilePath;
 		npx1Found->gainCalibrationFilePath = npx1Selected->gainCalibrationFilePath;
@@ -186,7 +190,7 @@ void OnixSourceCanvas::updateSettingsInterfaceDataSource(std::shared_ptr<OnixDev
 	else if (device->type == OnixDeviceType::OUTPUTCLOCK)
 	{
 		auto outputClockFound = std::static_pointer_cast<OutputClock>(device);
-		auto outputClockSelected = std::static_pointer_cast<OutputClock>(settingsInterfaces[ind]->device);
+		auto outputClockSelected = std::static_pointer_cast<OutputClock>(selectedDevice);
 		outputClockFound->setDelay(outputClockSelected->getDelay());
 		outputClockFound->setDutyCycle(outputClockSelected->getDutyCycle());
 		outputClockFound->setFrequencyHz(outputClockSelected->getFrequencyHz());
@@ -195,7 +199,7 @@ void OnixSourceCanvas::updateSettingsInterfaceDataSource(std::shared_ptr<OnixDev
 	else if (device->type == OnixDeviceType::ANALOGIO)
 	{
 		auto analogIOFound = std::static_pointer_cast<AnalogIO>(device);
-		auto analogIOSelected = std::static_pointer_cast<AnalogIO>(settingsInterfaces[ind]->device);
+		auto analogIOSelected = std::static_pointer_cast<AnalogIO>(selectedDevice);
 		for (int i = 0; i < analogIOFound->getNumChannels(); i++)
 		{
 			analogIOFound->setChannelDirection(i, analogIOSelected->getChannelDirection(i));
@@ -204,7 +208,7 @@ void OnixSourceCanvas::updateSettingsInterfaceDataSource(std::shared_ptr<OnixDev
 	else if (device->type == OnixDeviceType::NEUROPIXELSV2E)
 	{
 		auto npx2Found = std::static_pointer_cast<Neuropixels2e>(device);
-		auto npx2Selected = std::static_pointer_cast<Neuropixels2e>(settingsInterfaces[ind]->device);
+		auto npx2Selected = std::static_pointer_cast<Neuropixels2e>(device);
 		npx2Found->setSettings(npx2Selected->settings[0].get(), 0);
 		npx2Found->setSettings(npx2Selected->settings[1].get(), 1);
 		npx2Found->setGainCorrectionFile(0, npx2Selected->getGainCorrectionFile(0));
@@ -213,9 +217,8 @@ void OnixSourceCanvas::updateSettingsInterfaceDataSource(std::shared_ptr<OnixDev
 		std::static_pointer_cast<NeuropixelsV2eInterface>(settingsInterfaces[ind])->updateDevice(npx2Found);
 	}
 
-	device->setEnabled(settingsInterfaces[ind]->device->isEnabled());
-	settingsInterfaces[ind]->device.reset();
-	settingsInterfaces[ind]->device = device;
+	device->setEnabled(selectedDevice->isEnabled());
+	settingsInterfaces[ind]->setDevice(device);
 }
 
 String OnixSourceCanvas::getTopLevelTabName(PortName port, String headstage)
@@ -263,7 +266,9 @@ void OnixSourceCanvas::removeTabs(PortName port)
 
 	for (int i = settingsInterfaces.size() - 1; i >= 0; i -= 1)
 	{
-		if ((settingsInterfaces[i]->device->getDeviceIdx() & offset) > 0)
+		auto selectedDevice = settingsInterfaces[i]->getDevice();
+
+		if ((selectedDevice->getDeviceIdx() & offset) > 0)
 		{
 			settingsInterfaces.erase(settingsInterfaces.begin() + i);
 			tabExists = true;
@@ -293,7 +298,9 @@ std::map<int, OnixDeviceType> OnixSourceCanvas::createSelectedMap(std::vector<st
 
 	for (const auto& settings : interfaces)
 	{
-		tabMap.insert({ settings->device->getDeviceIdx(), settings->device->type });
+		auto device = settings->getDevice();
+
+		tabMap.insert({ device->getDeviceIdx(), device->type });
 	}
 
 	return tabMap;
@@ -512,10 +519,7 @@ void OnixSourceCanvas::startAcquisition()
 {
 	for (const auto& settingsInterface : settingsInterfaces)
 	{
-		if (settingsInterface->device != nullptr && settingsInterface->device->isEnabled())
-		{
-			settingsInterface->startAcquisition();
-		}
+		settingsInterface->startAcquisition();
 	}
 }
 
@@ -523,10 +527,7 @@ void OnixSourceCanvas::stopAcquisition()
 {
 	for (const auto& settingsInterface : settingsInterfaces)
 	{
-		if (settingsInterface->device != nullptr && settingsInterface->device->isEnabled())
-		{
-			settingsInterface->stopAcquisition();
-		}
+		settingsInterface->stopAcquisition();
 	}
 }
 

--- a/Source/OnixSourceEditor.cpp
+++ b/Source/OnixSourceEditor.cpp
@@ -142,7 +142,7 @@ void OnixSourceEditor::labelTextChanged(Label* l)
 	// TODO: Add headstage specific parameters to limit voltage within safe levels
 	if (l == portVoltageValueA.get())
 	{
-		if (l->getText() == "")
+		if (l->getText() == "" || l->getText() == "Auto")
 		{
 			l->setText("Auto", dontSendNotification);
 			return;
@@ -161,7 +161,7 @@ void OnixSourceEditor::labelTextChanged(Label* l)
 	}
 	else if (l == portVoltageValueB.get())
 	{
-		if (l->getText() == "")
+		if (l->getText() == "" || l->getText() == "Auto")
 		{
 			l->setText("Auto", dontSendNotification);
 			return;
@@ -439,9 +439,12 @@ void OnixSourceEditor::setComboBoxSelection(ComboBox* comboBox, String headstage
 	{
 		if (headstage.contains(comboBox->getItemText(i)))
 		{
-			comboBox->setSelectedItemIndex(i, dontSendNotification);
+			comboBox->setSelectedItemIndex(i, dontSendNotification); // TODO: double check this indexing
+			return;
 		}
 	}
+
+	comboBox->setSelectedItemIndex(0, dontSendNotification);
 }
 
 void OnixSourceEditor::refreshComboBoxSelection()
@@ -473,4 +476,29 @@ void OnixSourceEditor::refreshComboBoxSelection()
 std::map<int, OnixDeviceType> OnixSourceEditor::createTabMapFromCanvas()
 {
 	return canvas->createSelectedMap(canvas->settingsInterfaces);
+}
+
+void OnixSourceEditor::saveVisualizerEditorParameters(XmlElement* xml)
+{
+	LOGD("Saving OnixSourceEditor settings.");
+
+	xml->setAttribute("headstagePortA", headstageComboBoxA->getText());
+	xml->setAttribute("headstagePortB", headstageComboBoxB->getText());
+
+	xml->setAttribute("portVoltageA", portVoltageValueA->getText());
+	xml->setAttribute("portVoltageB", portVoltageValueB->getText());
+}
+
+void OnixSourceEditor::loadVisualizerEditorParameters(XmlElement* xml)
+{
+	LOGD("Loading OnixSourceEditor settings.");
+
+	setComboBoxSelection(headstageComboBoxA.get(), xml->getStringAttribute("headstagePortA"));
+	updateComboBox(headstageComboBoxA.get());
+
+	setComboBoxSelection(headstageComboBoxB.get(), xml->getStringAttribute("headstagePortB"));
+	updateComboBox(headstageComboBoxB.get());
+
+	portVoltageValueA->setText(xml->getStringAttribute("portVoltageA"), sendNotification);
+	portVoltageValueB->setText(xml->getStringAttribute("portVoltageB"), sendNotification);
 }

--- a/Source/OnixSourceEditor.cpp
+++ b/Source/OnixSourceEditor.cpp
@@ -327,10 +327,17 @@ void OnixSourceEditor::updateSettings()
 		canvas->update();
 }
 
+void OnixSourceEditor::setInterfaceEnabledState(bool newState)
+{
+	connectButton->setEnabled(newState);
+
+	portVoltageValueA->setEnabled(newState);
+	portVoltageValueB->setEnabled(newState);
+}
+
 void OnixSourceEditor::startAcquisition()
 {
-	// TODO: Disable all UI elements that should not be changed during acquisition...
-	connectButton->setEnabled(false);
+	setInterfaceEnabledState(false);
 
 	for (const auto& source : source->getDataSources())
 	{
@@ -341,12 +348,14 @@ void OnixSourceEditor::startAcquisition()
 			break;
 		}
 	}
+
+	if (canvas != nullptr)
+		canvas->startAcquisition();
 }
 
 void OnixSourceEditor::stopAcquisition()
 {
-	// TODO: Re-enable all of the UI elements 
-	connectButton->setEnabled(true);
+	setInterfaceEnabledState(true);
 
 	for (const auto& source : source->getDataSources())
 	{
@@ -356,6 +365,9 @@ void OnixSourceEditor::stopAcquisition()
 			break;
 		}
 	}
+
+	if (canvas != nullptr)
+		canvas->stopAcquisition();
 }
 
 Visualizer* OnixSourceEditor::createNewCanvas(void)

--- a/Source/OnixSourceEditor.cpp
+++ b/Source/OnixSourceEditor.cpp
@@ -319,6 +319,43 @@ void OnixSourceEditor::updateComboBox(ComboBox* cb)
 	}
 
 	source->getParameter(passthroughName)->setNextValue(passthroughValue);
+
+	String voltage = isPortA ? portVoltageValueA->getText() : portVoltageValueB->getText();
+
+	if (voltage != "Auto")
+	{
+		if (!currentHeadstageSelected)
+		{
+			if (isPortA)
+				portVoltageValueA->setText("", sendNotification);
+			else
+				portVoltageValueB->setText("", sendNotification);
+		}
+		else
+		{
+			int result = AlertWindow::show(MessageBoxOptions()
+				.withIconType(MessageBoxIconType::InfoIcon)
+				.withTitle("Voltage Override")
+				.withMessage(String("There is currently a voltage override selected for this port. Would you like to keep this voltage [Keep Voltage] ") +
+					"or allow the automated voltage discovery algorithm [Automated Discovery] to determine the best voltage for the new headstage selected?")
+				.withButton("Keep Voltage")
+				.withButton("Automated Discovery"));
+
+			switch (result)
+			{
+			case 1: // Keep Voltage
+				break;
+			case 0: // Automated Discovery
+				if (isPortA)
+					portVoltageValueA->setText("", sendNotification);
+				else
+					portVoltageValueB->setText("", sendNotification);
+				break;
+			default:
+				break;
+			}
+		}
+	}
 }
 
 void OnixSourceEditor::updateSettings()

--- a/Source/OnixSourceEditor.h
+++ b/Source/OnixSourceEditor.h
@@ -89,6 +89,17 @@ private:
     OnixSourceCanvas* canvas;
     OnixSource* source;
 
+    const FillType fillDisconnected = FillType(Colours::transparentBlack);
+    const FillType fillSearching = FillType(Colours::green);    // OR: use FillType(Colour::fromFloatRGBA(0.5f, 0.5f, 0.5f, 1.0f));
+    const FillType fillConnected = FillType(Colours::purple);
+
+    const Colour statusIndicatorStrokeColor = Colours::black;
+
+    const float statusIndicatorStrokeThickness = 1.0f;
+
+    std::unique_ptr<DrawableRectangle> portStatusA;
+    std::unique_ptr<DrawableRectangle> portStatusB;
+
     std::unique_ptr<Label> portLabelA;
     std::unique_ptr<Label> portLabelB;
 

--- a/Source/OnixSourceEditor.h
+++ b/Source/OnixSourceEditor.h
@@ -56,6 +56,8 @@ public:
 
     void updateSettings() override;
 
+    void setInterfaceEnabledState(bool newState);
+
     void startAcquisition() override;
 
     void stopAcquisition() override;
@@ -76,7 +78,6 @@ public:
 
     String getHeadstageSelected(PortName port);
 
-    /** Updates the combo boxes based on the headstages found in the canvas tabs */
     void refreshComboBoxSelection();
 
     std::map<int, OnixDeviceType> createTabMapFromCanvas();

--- a/Source/OnixSourceEditor.h
+++ b/Source/OnixSourceEditor.h
@@ -90,8 +90,8 @@ private:
     OnixSource* source;
 
     const FillType fillDisconnected = FillType(Colours::transparentBlack);
-    const FillType fillSearching = FillType(Colours::green);    // OR: use FillType(Colour::fromFloatRGBA(0.5f, 0.5f, 0.5f, 1.0f));
-    const FillType fillConnected = FillType(Colours::purple);
+    const FillType fillSearching = FillType(Colour::fromFloatRGBA(0.0f, 1.0f, 87.0f / 255, 1.0f));
+    const FillType fillConnected = FillType(Colour::fromFloatRGBA(184.0f / 255, 0.0f, 252.0f / 255, 1.0f));
 
     const Colour statusIndicatorStrokeColor = Colours::black;
 

--- a/Source/OnixSourceEditor.h
+++ b/Source/OnixSourceEditor.h
@@ -62,6 +62,10 @@ public:
 
     Visualizer* createNewCanvas(void) override;
 
+    void saveVisualizerEditorParameters(XmlElement* xml) override;
+
+    void loadVisualizerEditorParameters(XmlElement* xml) override;
+
     void checkCanvas() { checkForCanvas(); };
 
     void resetCanvas();

--- a/Source/UI/AnalogIOInterface.cpp
+++ b/Source/UI/AnalogIOInterface.cpp
@@ -78,6 +78,18 @@ AnalogIOInterface::AnalogIOInterface(std::shared_ptr<AnalogIO> d, OnixSourceEdit
 	type = SettingsInterface::Type::ANALOGIO_SETTINGS_INTERFACE;
 }
 
+void AnalogIOInterface::setInterfaceEnabledState(bool newState)
+{
+	if (deviceEnableButton != nullptr)
+		deviceEnableButton->setEnabled(newState);
+
+	for (int i = 0; i < numChannels; i++)
+	{
+		if (channelDirectionComboBoxes[i] != nullptr)
+			channelDirectionComboBoxes[i]->setEnabled(newState);
+	}
+}
+
 void AnalogIOInterface::updateSettings()
 {
 	if (device == nullptr) return;

--- a/Source/UI/AnalogIOInterface.cpp
+++ b/Source/UI/AnalogIOInterface.cpp
@@ -81,6 +81,18 @@ AnalogIOInterface::AnalogIOInterface(std::shared_ptr<AnalogIO> d, OnixSourceEdit
 	type = SettingsInterface::Type::ANALOGIO_SETTINGS_INTERFACE;
 }
 
+void AnalogIOInterface::updateSettings()
+{
+	deviceEnableButton->setToggleState(device->isEnabled(), dontSendNotification);
+
+	auto analogIO = std::static_pointer_cast<AnalogIO>(device);
+
+	for (int i = 0; i < numChannels; i++)
+	{
+		channelDirectionComboBoxes[i]->setSelectedId(getChannelDirectionId(analogIO, i), dontSendNotification);
+	}
+}
+
 void AnalogIOInterface::buttonClicked(Button* button)
 {
 	if (button == deviceEnableButton.get())

--- a/Source/UI/AnalogIOInterface.h
+++ b/Source/UI/AnalogIOInterface.h
@@ -44,10 +44,10 @@ public:
 	void stopAcquisition() override {};
 
 	/** Save parameters to XML */
-	void saveParameters(XmlElement* xml) override {};
+	void saveParameters(XmlElement* xml) override;
 
 	/** Load parameters from XML */
-	void loadParameters(XmlElement* xml) override {};
+	void loadParameters(XmlElement* xml) override;
 
 	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override {};
@@ -70,6 +70,7 @@ private:
 	static int getChannelDirectionId(std::shared_ptr<AnalogIO> device, int channelNumber);
 	static int getChannelVoltageRangeId(std::shared_ptr<AnalogIO> device, int channelNumber);
 	static int getDataTypeId(std::shared_ptr<AnalogIO> device);
+	static AnalogIODirection getChannelDirectionFromString(String direction);
 
 	JUCE_LEAK_DETECTOR(AnalogIOInterface);
 };

--- a/Source/UI/AnalogIOInterface.h
+++ b/Source/UI/AnalogIOInterface.h
@@ -34,31 +34,22 @@ class AnalogIOInterface : public SettingsInterface,
 	public ComboBox::Listener
 {
 public:
-	/** Constructor */
 	AnalogIOInterface(std::shared_ptr<AnalogIO> d, OnixSourceEditor* e, OnixSourceCanvas* c);
 
-	/** Disables buttons and starts animation if necessary */
-	void startAcquisition() override {};
-
-	/** Enables buttons and start animation if necessary */
-	void stopAcquisition() override {};
-
-	/** Save parameters to XML */
 	void saveParameters(XmlElement* xml) override;
 
-	/** Load parameters from XML */
 	void loadParameters(XmlElement* xml) override;
 
-	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override {};
 
 	void updateSettings() override;
 
-	/** Listener methods*/
 	void buttonClicked(Button*) override;
 	void comboBoxChanged(ComboBox* cb) override;
 
 private:
+
+	void setInterfaceEnabledState(bool newState) override;
 
 	static const int numChannels = 12;
 

--- a/Source/UI/AnalogIOInterface.h
+++ b/Source/UI/AnalogIOInterface.h
@@ -52,6 +52,8 @@ public:
 	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override {};
 
+	void updateSettings() override;
+
 	/** Listener methods*/
 	void buttonClicked(Button*) override;
 	void comboBoxChanged(ComboBox* cb) override;

--- a/Source/UI/Bno055Interface.cpp
+++ b/Source/UI/Bno055Interface.cpp
@@ -88,12 +88,10 @@ void Bno055Interface::saveParameters(XmlElement* xml)
 
 	XmlElement* xmlNode = xml->createNewChildElement("BNO055");
 
-	auto bno055 = std::static_pointer_cast<Bno055>(device);
+	xmlNode->setAttribute("name", device->getName());
+	xmlNode->setAttribute("idx", (int)device->getDeviceIdx());
 
-	xmlNode->setAttribute("name", bno055->getName());
-	xmlNode->setAttribute("idx", (int)bno055->getDeviceIdx());
-
-	xmlNode->setAttribute("isEnabled", bno055->isEnabled());
+	xmlNode->setAttribute("isEnabled", device->isEnabled());
 }
 
 void Bno055Interface::loadParameters(XmlElement* xml)
@@ -102,16 +100,14 @@ void Bno055Interface::loadParameters(XmlElement* xml)
 
 	LOGD("Loading Bno055 settings.");
 
-	auto bno055 = std::static_pointer_cast<Bno055>(device);
-
 	XmlElement* xmlNode = nullptr;
 
 	for (auto* node : xml->getChildIterator())
 	{
 		if (node->hasTagName("BNO055"))
 		{
-			if (node->getStringAttribute("name") == bno055->getName() &&
-				node->getIntAttribute("idx") == bno055->getDeviceIdx())
+			if (node->getStringAttribute("name") == device->getName() &&
+				node->getIntAttribute("idx") == device->getDeviceIdx())
 			{
 				xmlNode = node;
 				break;

--- a/Source/UI/Bno055Interface.cpp
+++ b/Source/UI/Bno055Interface.cpp
@@ -42,6 +42,12 @@ Bno055Interface::Bno055Interface(std::shared_ptr<Bno055> d, OnixSourceEditor* e,
 	type = SettingsInterface::Type::BNO055_SETTINGS_INTERFACE;
 }
 
+void Bno055Interface::setInterfaceEnabledState(bool newState)
+{
+	if (deviceEnableButton != nullptr)
+		deviceEnableButton->setEnabled(newState);
+}
+
 void Bno055Interface::updateSettings()
 {
 	if (device == nullptr) return;

--- a/Source/UI/Bno055Interface.h
+++ b/Source/UI/Bno055Interface.h
@@ -36,24 +36,18 @@ public:
 	/** Constructor */
 	Bno055Interface(std::shared_ptr<Bno055> d, OnixSourceEditor* e, OnixSourceCanvas* c);
 
-	/** Disables buttons and starts animation if necessary */
 	void startAcquisition() override {};
 
-	/** Enables buttons and start animation if necessary */
 	void stopAcquisition() override {};
 
-	/** Save parameters to XML */
 	void saveParameters(XmlElement* xml) override;
 
-	/** Load parameters from XML */
 	void loadParameters(XmlElement* xml) override;
 
-	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override {};
 
 	void updateSettings() override;
 
-	/** Listener methods*/
 	void buttonClicked(Button*) override;
 
 private:

--- a/Source/UI/Bno055Interface.h
+++ b/Source/UI/Bno055Interface.h
@@ -43,15 +43,15 @@ public:
 	void stopAcquisition() override {};
 
 	/** Save parameters to XML */
-	void saveParameters(XmlElement* xml) override {};
+	void saveParameters(XmlElement* xml) override;
 
 	/** Load parameters from XML */
-	void loadParameters(XmlElement* xml) override {};
+	void loadParameters(XmlElement* xml) override;
 
 	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override {};
 
-	void updateSettings() override {};
+	void updateSettings() override;
 
 	/** Listener methods*/
 	void buttonClicked(Button*) override;

--- a/Source/UI/Bno055Interface.h
+++ b/Source/UI/Bno055Interface.h
@@ -51,6 +51,8 @@ public:
 	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override {};
 
+	void updateSettings() override {};
+
 	/** Listener methods*/
 	void buttonClicked(Button*) override;
 

--- a/Source/UI/Bno055Interface.h
+++ b/Source/UI/Bno055Interface.h
@@ -33,12 +33,9 @@ class Bno055Interface : public SettingsInterface,
 	public Button::Listener
 {
 public:
-	/** Constructor */
 	Bno055Interface(std::shared_ptr<Bno055> d, OnixSourceEditor* e, OnixSourceCanvas* c);
 
-	void startAcquisition() override {};
-
-	void stopAcquisition() override {};
+	void setInterfaceEnabledState(bool newState) override;
 
 	void saveParameters(XmlElement* xml) override;
 

--- a/Source/UI/DigitalIOInterface.cpp
+++ b/Source/UI/DigitalIOInterface.cpp
@@ -42,6 +42,12 @@ DigitalIOInterface::DigitalIOInterface(std::shared_ptr<DigitalIO> d, OnixSourceE
 	type = SettingsInterface::Type::DIGITALIO_SETTINGS_INTERFACE;
 }
 
+void DigitalIOInterface::setInterfaceEnabledState(bool newState)
+{
+	if (deviceEnableButton != nullptr)
+		deviceEnableButton->setEnabled(newState);
+}
+
 void DigitalIOInterface::updateSettings()
 {
 	if (device == nullptr) return;

--- a/Source/UI/DigitalIOInterface.cpp
+++ b/Source/UI/DigitalIOInterface.cpp
@@ -42,6 +42,13 @@ DigitalIOInterface::DigitalIOInterface(std::shared_ptr<DigitalIO> d, OnixSourceE
 	type = SettingsInterface::Type::DIGITALIO_SETTINGS_INTERFACE;
 }
 
+void DigitalIOInterface::updateSettings()
+{
+	if (device == nullptr) return;
+
+	deviceEnableButton->setToggleState(device->isEnabled(), sendNotification);
+}
+
 void DigitalIOInterface::buttonClicked(Button* button)
 {
 	if (button == deviceEnableButton.get())
@@ -60,4 +67,34 @@ void DigitalIOInterface::buttonClicked(Button* button)
 
 		CoreServices::updateSignalChain(editor);
 	}
+}
+
+void DigitalIOInterface::saveParameters(XmlElement* xml)
+{
+	if (device == nullptr) return;
+
+	LOGD("Saving DigitalIO settings.");
+
+	XmlElement* xmlNode = xml->createNewChildElement("DIGITALIO");
+
+	xmlNode->setAttribute("isEnabled", device->isEnabled());
+}
+
+void DigitalIOInterface::loadParameters(XmlElement* xml)
+{
+	if (device == nullptr) return;
+
+	LOGD("Loading DigitalIO settings.");
+
+	auto xmlNode = xml->getChildByName("DIGITALIO");
+
+	if (xmlNode == nullptr)
+	{
+		LOGE("No DIGITALIO element found.");
+		return;
+	}
+
+	device->setEnabled(xmlNode->getBoolAttribute("isEnabled"));
+
+	updateSettings();
 }

--- a/Source/UI/DigitalIOInterface.h
+++ b/Source/UI/DigitalIOInterface.h
@@ -43,15 +43,15 @@ public:
 	void stopAcquisition() override {};
 
 	/** Save parameters to XML */
-	void saveParameters(XmlElement* xml) override {};
+	void saveParameters(XmlElement* xml) override;
 
 	/** Load parameters from XML */
-	void loadParameters(XmlElement* xml) override {};
+	void loadParameters(XmlElement* xml) override;
 
 	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override {};
 
-	void updateSettings() override {};
+	void updateSettings() override;
 
 	/** Listener methods*/
 	void buttonClicked(Button*) override;

--- a/Source/UI/DigitalIOInterface.h
+++ b/Source/UI/DigitalIOInterface.h
@@ -51,6 +51,8 @@ public:
 	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override {};
 
+	void updateSettings() override {};
+
 	/** Listener methods*/
 	void buttonClicked(Button*) override;
 

--- a/Source/UI/DigitalIOInterface.h
+++ b/Source/UI/DigitalIOInterface.h
@@ -33,30 +33,21 @@ class DigitalIOInterface : public SettingsInterface,
 	public Button::Listener
 {
 public:
-	/** Constructor */
 	DigitalIOInterface(std::shared_ptr<DigitalIO> d, OnixSourceEditor* e, OnixSourceCanvas* c);
 
-	/** Disables buttons and starts animation if necessary */
-	void startAcquisition() override {};
-
-	/** Enables buttons and start animation if necessary */
-	void stopAcquisition() override {};
-
-	/** Save parameters to XML */
 	void saveParameters(XmlElement* xml) override;
 
-	/** Load parameters from XML */
 	void loadParameters(XmlElement* xml) override;
 
-	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override {};
 
 	void updateSettings() override;
 
-	/** Listener methods*/
 	void buttonClicked(Button*) override;
 
 private:
+
+	void setInterfaceEnabledState(bool newState) override;
 
 	std::unique_ptr<UtilityButton> deviceEnableButton;
 

--- a/Source/UI/HarpSyncInputInterface.cpp
+++ b/Source/UI/HarpSyncInputInterface.cpp
@@ -42,6 +42,13 @@ HarpSyncInputInterface::HarpSyncInputInterface(std::shared_ptr<HarpSyncInput> d,
 	type = SettingsInterface::Type::HARPSYNCINPUT_SETTINGS_INTERFACE;
 }
 
+void HarpSyncInputInterface::updateSettings()
+{
+	if (device == nullptr) return;
+
+	deviceEnableButton->setToggleState(device->isEnabled(), sendNotification);
+}
+
 void HarpSyncInputInterface::buttonClicked(Button* button)
 {
 	if (button == deviceEnableButton.get())
@@ -60,4 +67,34 @@ void HarpSyncInputInterface::buttonClicked(Button* button)
 
 		CoreServices::updateSignalChain(editor);
 	}
+}
+
+void HarpSyncInputInterface::saveParameters(XmlElement* xml)
+{
+	if (device == nullptr) return;
+
+	LOGD("Saving HarpSyncInput settings.");
+
+	XmlElement* xmlNode = xml->createNewChildElement("HARPSYNCINPUT");
+
+	xmlNode->setAttribute("isEnabled", device->isEnabled());
+}
+
+void HarpSyncInputInterface::loadParameters(XmlElement* xml)
+{
+	if (device == nullptr) return;
+
+	LOGD("Loading HarpSyncInput settings.");
+
+	auto xmlNode = xml->getChildByName("HARPSYNCINPUT");
+
+	if (xmlNode == nullptr)
+	{
+		LOGE("No HARPSYNCINPUT element found.");
+		return;
+	}
+
+	device->setEnabled(xmlNode->getBoolAttribute("isEnabled"));
+
+	updateSettings();
 }

--- a/Source/UI/HarpSyncInputInterface.cpp
+++ b/Source/UI/HarpSyncInputInterface.cpp
@@ -42,6 +42,12 @@ HarpSyncInputInterface::HarpSyncInputInterface(std::shared_ptr<HarpSyncInput> d,
 	type = SettingsInterface::Type::HARPSYNCINPUT_SETTINGS_INTERFACE;
 }
 
+void HarpSyncInputInterface::setInterfaceEnabledState(bool newState)
+{
+	if (deviceEnableButton != nullptr)
+		deviceEnableButton->setEnabled(newState);
+}
+
 void HarpSyncInputInterface::updateSettings()
 {
 	if (device == nullptr) return;

--- a/Source/UI/HarpSyncInputInterface.h
+++ b/Source/UI/HarpSyncInputInterface.h
@@ -36,26 +36,19 @@ public:
 
 	HarpSyncInputInterface(std::shared_ptr<HarpSyncInput> d, OnixSourceEditor* e, OnixSourceCanvas* c);
 
-	/** Disables buttons and starts animation if necessary */
-	void startAcquisition() override {};
-
-	/** Enables buttons and start animation if necessary */
-	void stopAcquisition() override {};
-
-	/** Save parameters to XML */
 	void saveParameters(XmlElement* xml) override;
 
-	/** Load parameters from XML */
 	void loadParameters(XmlElement* xml) override;
 
 	void updateInfoString() override {};
 
 	void updateSettings() override;
 
-	/** Listener methods*/
 	void buttonClicked(Button*) override;
 
 private:
+
+	void setInterfaceEnabledState(bool newState) override;
 
 	std::unique_ptr<UtilityButton> deviceEnableButton;
 

--- a/Source/UI/HarpSyncInputInterface.h
+++ b/Source/UI/HarpSyncInputInterface.h
@@ -43,14 +43,14 @@ public:
 	void stopAcquisition() override {};
 
 	/** Save parameters to XML */
-	void saveParameters(XmlElement* xml) override {};
+	void saveParameters(XmlElement* xml) override;
 
 	/** Load parameters from XML */
-	void loadParameters(XmlElement* xml) override {};
+	void loadParameters(XmlElement* xml) override;
 
 	void updateInfoString() override {};
 
-	void updateSettings() override {};
+	void updateSettings() override;
 
 	/** Listener methods*/
 	void buttonClicked(Button*) override;

--- a/Source/UI/HarpSyncInputInterface.h
+++ b/Source/UI/HarpSyncInputInterface.h
@@ -50,6 +50,8 @@ public:
 
 	void updateInfoString() override {};
 
+	void updateSettings() override {};
+
 	/** Listener methods*/
 	void buttonClicked(Button*) override;
 

--- a/Source/UI/NeuropixV1Interface.cpp
+++ b/Source/UI/NeuropixV1Interface.cpp
@@ -825,26 +825,6 @@ int NeuropixV1Interface::getIndexOfComboBoxItem(ComboBox* cb, String item)
 	return -1;
 }
 
-void NeuropixV1Interface::setApGain(int index)
-{
-	apGainComboBox->setSelectedId(index + 1, sendNotification);
-}
-
-void NeuropixV1Interface::setLfpGain(int index)
-{
-	lfpGainComboBox->setSelectedId(index + 1, sendNotification);
-}
-
-void NeuropixV1Interface::setReference(int index)
-{
-	referenceComboBox->setSelectedId(index + 1, sendNotification);
-}
-
-void NeuropixV1Interface::setApFilterState(bool state)
-{
-	filterComboBox->setSelectedId(int(!state) + 1, sendNotification);
-}
-
 void NeuropixV1Interface::selectElectrodes(std::vector<int> electrodes)
 {
 	std::static_pointer_cast<Neuropixels_1>(device)->settings[0]->selectElectrodes(electrodes);
@@ -875,8 +855,20 @@ void NeuropixV1Interface::setInterfaceEnabledState(bool enabledState)
 	if (referenceComboBox != nullptr)
 		referenceComboBox->setEnabled(enabledState);
 
+	if (saveJsonButton != nullptr)
+		saveJsonButton->setEnabled(enabledState);
+
 	if (loadJsonButton != nullptr)
 		loadJsonButton->setEnabled(enabledState);
+
+	if (offsetCorrectionCheckbox != nullptr)
+		offsetCorrectionCheckbox->setEnabled(enabledState);
+
+	if (adcCalibrationFileButton != nullptr)
+		adcCalibrationFileButton->setEnabled(enabledState);
+
+	if (gainCalibrationFileButton != nullptr)
+		gainCalibrationFileButton->setEnabled(enabledState);
 }
 
 void NeuropixV1Interface::startAcquisition()

--- a/Source/UI/NeuropixV1Interface.cpp
+++ b/Source/UI/NeuropixV1Interface.cpp
@@ -998,9 +998,6 @@ void NeuropixV1Interface::saveParameters(XmlElement* xml)
 	probeViewerNode->setAttribute("referenceChannel", referenceComboBox->getText());
 	probeViewerNode->setAttribute("apFilter", filterComboBox->getText());
 
-	probeViewerNode->setAttribute("visualizationMode", (int)mode);
-	probeViewerNode->setAttribute("activityToView", (int)probeBrowser->activityToView);
-
 	XmlElement* channelsNode = xmlNode->createNewChildElement("SELECTED_CHANNELS");
 
 	for (int i = 0; i < settings->selectedElectrode.size(); i++)
@@ -1095,9 +1092,6 @@ void NeuropixV1Interface::loadParameters(XmlElement* xml)
 	else
 		settings->apFilterState = idx == 1 ? true : false;
 
-	mode = (VisualizationMode)probeViewerNode->getIntAttribute("visualizationMode");
-	probeBrowser->activityToView = (ActivityToView)probeViewerNode->getIntAttribute("activityToView");
-
 	XmlElement* channelsNode = xmlNode->getChildByName("SELECTED_CHANNELS");
 
 	if (channelsNode == nullptr)
@@ -1128,7 +1122,7 @@ void NeuropixV1Interface::loadParameters(XmlElement* xml)
 
 	if (selectedChannels.size() != npx->numberOfChannels)
 	{
-		LOGE("Invalid channel map. Some duplicate channels were found. Channel map was not updated");
+		LOGE("Invalid channel map. Wrong number of channels found. Channel map was not updated");
 		return;
 	}
 

--- a/Source/UI/NeuropixV1Interface.h
+++ b/Source/UI/NeuropixV1Interface.h
@@ -58,7 +58,7 @@ public:
 	void stopAcquisition() override;
 
 	/** Settings-related functions*/
-	bool applyProbeSettings(ProbeSettings<Neuropixels_1::numberOfChannels, Neuropixels_1::numberOfElectrodes>* p, bool shouldUpdateProbe = true);
+	bool applyProbeSettings(ProbeSettings<Neuropixels_1::numberOfChannels, Neuropixels_1::numberOfElectrodes>* p);
 
 	/** Save parameters to XML */
 	void saveParameters(XmlElement* xml) override;
@@ -69,7 +69,7 @@ public:
 	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override;
 
-	void updateSettings() override {};
+	void updateSettings() override;
 
 	/** Set parameters */
 	void setApGain(int index);
@@ -158,6 +158,8 @@ private:
 
 	/** Checks if the current channel map matches an existing channel preset, and updates the combo box if it does */
 	void checkForExistingChannelPreset();
+
+	int getIndexOfComboBoxItem(ComboBox* cb, String item);
 
 	JUCE_LEAK_DETECTOR(NeuropixV1Interface);
 };

--- a/Source/UI/NeuropixV1Interface.h
+++ b/Source/UI/NeuropixV1Interface.h
@@ -44,43 +44,34 @@ class NeuropixV1Interface : public SettingsInterface,
 public:
 	friend class ProbeBrowser<Neuropixels_1::numberOfChannels, Neuropixels_1::numberOfElectrodes>;
 
-	/** Constructor */
 	NeuropixV1Interface(std::shared_ptr<Neuropixels_1> d, OnixSourceEditor* e, OnixSourceCanvas* c);
-
-	/** Listener methods*/
+	
 	void buttonClicked(Button*) override;
 	void comboBoxChanged(ComboBox*) override;
 
-	/** Disables buttons and starts animation if necessary */
 	void startAcquisition() override;
 
-	/** Enables buttons and start animation if necessary */
 	void stopAcquisition() override;
 
 	/** Settings-related functions*/
 	bool applyProbeSettings(ProbeSettings<Neuropixels_1::numberOfChannels, Neuropixels_1::numberOfElectrodes>* p);
 
-	/** Save parameters to XML */
 	void saveParameters(XmlElement* xml) override;
 
-	/** Load parameters from XML */
 	void loadParameters(XmlElement* xml) override;
 
-	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override;
 
 	void updateSettings() override;
 
-	/** Set parameters */
-	void setApGain(int index);
-	void setLfpGain(int index);
-	void setReference(int index);
-	void setApFilterState(bool state);
 	void selectElectrodes(std::vector<int> electrodes);
 
 	String getReferenceText() override { return referenceComboBox->getText(); }
 
 private:
+
+	void setInterfaceEnabledState(bool newState) override;
+
 	XmlElement neuropix_info;
 
 	bool acquisitionIsActive = false;
@@ -153,8 +144,6 @@ private:
 	void drawLegend();
 
 	std::vector<int> getSelectedElectrodes() const;
-
-	void setInterfaceEnabledState(bool enabledState);
 
 	/** Checks if the current channel map matches an existing channel preset, and updates the combo box if it does */
 	void checkForExistingChannelPreset();

--- a/Source/UI/NeuropixV1Interface.h
+++ b/Source/UI/NeuropixV1Interface.h
@@ -69,6 +69,8 @@ public:
 	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override;
 
+	void updateSettings() override {};
+
 	/** Set parameters */
 	void setApGain(int index);
 	void setLfpGain(int index);

--- a/Source/UI/NeuropixelsV1fProbeBrowser.h
+++ b/Source/UI/NeuropixelsV1fProbeBrowser.h
@@ -38,6 +38,6 @@ public:
 
 	ProbeSettings<NeuropixelsV1fValues::numberOfChannels, NeuropixelsV1fValues::numberOfElectrodes>* getSettings() override
 	{
-		return std::static_pointer_cast<Neuropixels_1>(parent->device)->settings[0].get();
+		return std::static_pointer_cast<Neuropixels_1>(parent->getDevice())->settings[0].get();
 	}
 };

--- a/Source/UI/NeuropixelsV2eInterface.cpp
+++ b/Source/UI/NeuropixelsV2eInterface.cpp
@@ -104,3 +104,13 @@ void NeuropixelsV2eInterface::buttonClicked(Button* b)
 		CoreServices::updateSignalChain(editor);
 	}
 }
+
+void NeuropixelsV2eInterface::updateSettings()
+{
+	if (device == nullptr) return;
+
+	for (const auto& probeInterface : probeInterfaces)
+	{
+		probeInterface->updateSettings();
+	}
+}

--- a/Source/UI/NeuropixelsV2eInterface.cpp
+++ b/Source/UI/NeuropixelsV2eInterface.cpp
@@ -63,7 +63,7 @@ void NeuropixelsV2eInterface::updateDevice(std::shared_ptr<Neuropixels2e> d)
 
 	for (const auto& probeInterface : probeInterfaces)
 	{
-		probeInterface->device = device;
+		probeInterface->setDevice(device);
 	}
 }
 
@@ -112,5 +112,18 @@ void NeuropixelsV2eInterface::updateSettings()
 	for (const auto& probeInterface : probeInterfaces)
 	{
 		probeInterface->updateSettings();
+	}
+}
+
+void NeuropixelsV2eInterface::setInterfaceEnabledState(bool newState)
+{
+	if (device == nullptr) return;
+
+	if (probeEnableButton != nullptr)
+		probeEnableButton->setEnabled(newState);
+
+	for (const auto& probeInterface : probeInterfaces)
+	{
+		probeInterface->setInterfaceEnabledState(newState);
 	}
 }

--- a/Source/UI/NeuropixelsV2eInterface.h
+++ b/Source/UI/NeuropixelsV2eInterface.h
@@ -53,6 +53,8 @@ public:
 
 private:
 
+	void setInterfaceEnabledState(bool newState) override;
+
 	std::unique_ptr<CustomTabComponent> topLevelTabComponent;
 
 	std::unique_ptr<UtilityButton> probeEnableButton;

--- a/Source/UI/NeuropixelsV2eInterface.h
+++ b/Source/UI/NeuropixelsV2eInterface.h
@@ -47,6 +47,8 @@ public:
 
 	void buttonClicked(Button* b) override;
 
+	void updateSettings() override;
+
 	void updateDevice(std::shared_ptr<Neuropixels2e> d);
 
 private:

--- a/Source/UI/NeuropixelsV2eInterface.h
+++ b/Source/UI/NeuropixelsV2eInterface.h
@@ -33,13 +33,9 @@ class NeuropixelsV2eInterface : public SettingsInterface,
 public:
 	NeuropixelsV2eInterface(std::shared_ptr<Neuropixels2e> d, OnixSourceEditor* e, OnixSourceCanvas* c);
 
-	void startAcquisition() override {};
+	void saveParameters(XmlElement* xml) override;
 
-	void stopAcquisition() override {};
-
-	void saveParameters(XmlElement* xml) override {};
-
-	void loadParameters(XmlElement* xml) override {};
+	void loadParameters(XmlElement* xml) override;
 
 	void updateInfoString() override;
 
@@ -57,7 +53,7 @@ private:
 
 	std::unique_ptr<CustomTabComponent> topLevelTabComponent;
 
-	std::unique_ptr<UtilityButton> probeEnableButton;
+	std::unique_ptr<UtilityButton> deviceEnableButton;
 	std::unique_ptr<Component> deviceComponent;
 
 	static const int numProbes = 2;

--- a/Source/UI/NeuropixelsV2eProbeBrowser.h
+++ b/Source/UI/NeuropixelsV2eProbeBrowser.h
@@ -38,6 +38,6 @@ public:
 
 	ProbeSettings<NeuropixelsV2eValues::numberOfChannels, NeuropixelsV2eValues::numberOfElectrodes>* getSettings() override
 	{
-		return std::static_pointer_cast<Neuropixels2e>(parent->device)->settings[probeIndex].get();
+		return std::static_pointer_cast<Neuropixels2e>(parent->getDevice())->settings[probeIndex].get();
 	}
 };

--- a/Source/UI/NeuropixelsV2eProbeInterface.cpp
+++ b/Source/UI/NeuropixelsV2eProbeInterface.cpp
@@ -627,6 +627,18 @@ void NeuropixelsV2eProbeInterface::drawLegend()
 	}
 }
 
+void NeuropixelsV2eProbeInterface::updateSettings()
+{
+	if (device == nullptr) return;
+
+	auto npx = std::static_pointer_cast<Neuropixels2e>(device);
+
+	applyProbeSettings(npx->settings[probeIndex].get());
+	checkForExistingChannelPreset();
+
+	gainCorrectionFile->setText(npx->getGainCorrectionFile(probeIndex) == "None" ? "" : npx->getGainCorrectionFile(probeIndex), dontSendNotification);
+}
+
 bool NeuropixelsV2eProbeInterface::applyProbeSettings(ProbeSettings<Neuropixels2e::numberOfChannels, Neuropixels2e::numberOfElectrodes>* p, bool shouldUpdateProbe)
 {
 	if (electrodeConfigurationComboBox != 0)

--- a/Source/UI/NeuropixelsV2eProbeInterface.cpp
+++ b/Source/UI/NeuropixelsV2eProbeInterface.cpp
@@ -183,40 +183,7 @@ NeuropixelsV2eProbeInterface::NeuropixelsV2eProbeInterface(std::shared_ptr<Neuro
 
 			currentHeight += 55;
 		}
-
-		currentHeight += 55;
-
-		activityViewButton = std::make_unique<UtilityButton>("VIEW");
-		activityViewButton->setFont(fontRegularButton);
-		activityViewButton->setRadius(3.0f);
-
-		activityViewButton->addListener(this);
-		activityViewButton->setTooltip("View peak-to-peak amplitudes for each channel");
-		addAndMakeVisible(activityViewButton.get());
-
-		activityViewComboBox = std::make_unique<ComboBox>("ActivityView Combo Box");
-
-		if (settings->availableLfpGains.size() > 0)
-		{
-			activityViewComboBox->setBounds(450, currentHeight, 65, 22);
-			activityViewComboBox->addListener(this);
-			activityViewComboBox->addItem("AP", 1);
-			activityViewComboBox->addItem("LFP", 2);
-			activityViewComboBox->setSelectedId(1, dontSendNotification);
-			addAndMakeVisible(activityViewComboBox.get());
-			activityViewButton->setBounds(530, currentHeight + 2, 45, 18);
-		}
-		else
-		{
-			activityViewButton->setBounds(450, currentHeight + 2, 45, 18);
-		}
-
-		activityViewLabel = std::make_unique<Label>("PROBE SIGNAL", "PROBE SIGNAL");
-		activityViewLabel->setFont(fontRegularLabel);
-		activityViewLabel->setBounds(446, currentHeight - 20, 180, 20);
-		addAndMakeVisible(activityViewLabel.get());
-
-		/// Draw Legends
+#pragma region Draw Legends
 
 		// ENABLE View
 		Colour colour = Colour(55, 55, 55);
@@ -336,10 +303,8 @@ NeuropixelsV2eProbeInterface::NeuropixelsV2eProbeInterface(std::shared_ptr<Neuro
 		}
 
 		addAndMakeVisible(activityViewComponent.get());
-	}
-	else
-	{
-		type = SettingsInterface::Type::UNKNOWN_SETTINGS_INTERFACE;
+
+#pragma endregion
 	}
 
 	drawLegend();
@@ -370,64 +335,22 @@ void NeuropixelsV2eProbeInterface::updateInfoString()
 
 void NeuropixelsV2eProbeInterface::comboBoxChanged(ComboBox* comboBox)
 {
-	if (!editor->acquisitionIsActive)
+	auto npx = std::static_pointer_cast<Neuropixels2e>(device);
+
+	if (comboBox == electrodeConfigurationComboBox.get())
 	{
-		auto npx = std::static_pointer_cast<Neuropixels2e>(device);
+		String preset = electrodeConfigurationComboBox->getText();
 
-		if (comboBox == electrodeConfigurationComboBox.get())
-		{
-			String preset = electrodeConfigurationComboBox->getText();
+		auto selection = npx->selectElectrodeConfiguration(preset);
 
-			auto selection = npx->selectElectrodeConfiguration(preset);
-
-			selectElectrodes(selection);
-		}
-		else if (comboBox == referenceComboBox.get())
-		{
-			npx->settings[probeIndex]->referenceIndex = referenceComboBox->getSelectedItemIndex();
-		}
-		else if (comboBox == activityViewComboBox.get())
-		{
-			if (comboBox->getSelectedId() == 1)
-			{
-				probeBrowser->activityToView = ActivityToView::APVIEW;
-				ColourScheme::setColourScheme(ColourSchemeId::PLASMA);
-				probeBrowser->maxPeakToPeakAmplitude = 250.0f;
-			}
-			else
-			{
-				probeBrowser->activityToView = ActivityToView::LFPVIEW;
-				ColourScheme::setColourScheme(ColourSchemeId::VIRIDIS);
-				probeBrowser->maxPeakToPeakAmplitude = 500.0f;
-			}
-		}
-
-		repaint();
+		selectElectrodes(selection);
 	}
-	else
+	else if (comboBox == referenceComboBox.get())
 	{
-		if (comboBox == activityViewComboBox.get())
-		{
-			if (comboBox->getSelectedId() == 1)
-			{
-				probeBrowser->activityToView = ActivityToView::APVIEW;
-				ColourScheme::setColourScheme(ColourSchemeId::PLASMA);
-				probeBrowser->maxPeakToPeakAmplitude = 250.0f;
-			}
-			else
-			{
-				probeBrowser->activityToView = ActivityToView::LFPVIEW;
-				ColourScheme::setColourScheme(ColourSchemeId::VIRIDIS);
-				probeBrowser->maxPeakToPeakAmplitude = 500.0f;
-			}
-
-			repaint();
-		}
-		else
-		{
-			CoreServices::sendStatusMessage("Cannot update parameters while acquisition is active"); // no parameter change while acquisition is active
-		}
+		npx->settings[probeIndex]->referenceIndex = referenceComboBox->getSelectedItemIndex();
 	}
+
+	repaint();
 }
 
 void NeuropixelsV2eProbeInterface::checkForExistingChannelPreset()
@@ -445,7 +368,7 @@ void NeuropixelsV2eProbeInterface::checkForExistingChannelPreset()
 
 		for (int j = 0; j < selection.size(); j++)
 		{
-			channelMap[settings->electrodeMetadata[j].channel] = selection[j];
+			channelMap[settings->electrodeMetadata[selection[j]].channel] = selection[j];
 		}
 
 		if (std::equal(channelMap.cbegin(), channelMap.cend(), settings->selectedElectrode.cbegin(), settings->selectedElectrode.cend()))
@@ -473,16 +396,6 @@ void NeuropixelsV2eProbeInterface::buttonClicked(Button* button)
 	{
 		mode = VisualizationMode::REFERENCE_VIEW;
 		probeBrowser->stopTimer();
-		drawLegend();
-		repaint();
-	}
-	else if (button == activityViewButton.get())
-	{
-		mode = VisualizationMode::ACTIVITY_VIEW;
-
-		if (acquisitionIsActive)
-			probeBrowser->startTimer(100);
-
 		drawLegend();
 		repaint();
 	}
@@ -586,6 +499,12 @@ void NeuropixelsV2eProbeInterface::setInterfaceEnabledState(bool enabledState)
 
 	if (loadJsonButton != nullptr)
 		loadJsonButton->setEnabled(enabledState);
+
+	if (saveJsonButton != nullptr)
+		saveJsonButton->setEnabled(enabledState);
+
+	if (gainCorrectionFileButton != nullptr)
+		gainCorrectionFileButton->setEnabled(enabledState);
 }
 
 void NeuropixelsV2eProbeInterface::startAcquisition()
@@ -681,83 +600,137 @@ bool NeuropixelsV2eProbeInterface::applyProbeSettings(ProbeSettings<Neuropixels2
 	return true;
 }
 
+int NeuropixelsV2eProbeInterface::getIndexOfComboBoxItem(ComboBox* cb, String item)
+{
+	for (int i = 0; i < cb->getNumItems(); i++)
+	{
+		if (item == cb->getItemText(i))
+			return i;
+	}
+
+	return -1;
+}
+
 void NeuropixelsV2eProbeInterface::saveParameters(XmlElement* xml)
 {
-	/*if (device != nullptr)
+	if (device == nullptr) return;
+
+	LOGD("Saving Neuropixels 2.0e settings.");
+
+	auto npx = std::static_pointer_cast<Neuropixels2e>(device);
+	auto settings = npx->settings[probeIndex].get();
+
+	XmlElement* xmlNode = xml->createNewChildElement("PROBE" + String(probeIndex));
+
+	xmlNode->setAttribute("probeSerialNumber", String(npx->getProbeSerialNumber(probeIndex)));
+
+	xmlNode->setAttribute("gainCorrectionFile", npx->getGainCorrectionFile(probeIndex));
+
+	XmlElement* probeViewerNode = xmlNode->createNewChildElement("PROBE_VIEWER");
+
+	probeViewerNode->setAttribute("zoomHeight", probeBrowser->getZoomHeight());
+	probeViewerNode->setAttribute("zoomOffset", probeBrowser->getZoomOffset());
+
+	probeViewerNode->setAttribute("referenceChannel", referenceComboBox->getText());
+
+	XmlElement* channelsNode = xmlNode->createNewChildElement("SELECTED_CHANNELS");
+
+	for (int i = 0; i < settings->selectedElectrode.size(); i++)
 	{
-		auto npx = std::static_pointer_cast<Neuropixels2e>(device);
-		auto settings = npx->settings[probeIndex].get();
+		int globalIndex = settings->selectedElectrode[i];
 
-		LOGD("Saving Neuropix display.");
-
-		XmlElement* xmlNode = xml->createNewChildElement("NP_PROBE");
-
-		xmlNode->setAttribute("probe_serial_number", String(npx->getProbeSerialNumber(probeIndex)));
-		xmlNode->setAttribute("probe_name", npx->getName());
-		xmlNode->setAttribute("num_adcs", settings->probeMetadata.num_adcs);
-
-		xmlNode->setAttribute("ZoomHeight", probeBrowser->getZoomHeight());
-		xmlNode->setAttribute("ZoomOffset", probeBrowser->getZoomOffset());
-
-		if (electrodeConfigurationComboBox != nullptr)
-		{
-			if (electrodeConfigurationComboBox->getSelectedId() > 1)
-			{
-				xmlNode->setAttribute("electrodeConfigurationPreset", electrodeConfigurationComboBox->getText());
-			}
-			else
-			{
-				xmlNode->setAttribute("electrodeConfigurationPreset", "NONE");
-			}
-		}
-
-		if (referenceComboBox != nullptr)
-		{
-			if (referenceComboBox->getSelectedId() > 0)
-			{
-				xmlNode->setAttribute("referenceChannel", referenceComboBox->getText());
-				xmlNode->setAttribute("referenceChannelIndex", referenceComboBox->getSelectedId() - 1);
-			}
-			else
-			{
-				xmlNode->setAttribute("referenceChannel", "Ext");
-				xmlNode->setAttribute("referenceChannelIndex", 0);
-			}
-		}
-
-		XmlElement* channelNode = xmlNode->createNewChildElement("CHANNELS");
-		XmlElement* xposNode = xmlNode->createNewChildElement("ELECTRODE_XPOS");
-		XmlElement* yposNode = xmlNode->createNewChildElement("ELECTRODE_YPOS");
-
-		for (int i = 0; i < settings->selectedElectrode.size(); i++)
-		{
-			int bank = int(settings->selectedBank[i]);
-			int shank = settings->selectedShank[i];
-			int elec = settings->selectedElectrode[i];
-
-			String chString = String(bank);
-
-			String chId = "CH" + String(i);
-
-			channelNode->setAttribute(chId, chString);
-			xposNode->setAttribute(chId, String(settings->electrodeMetadata[elec].xpos + 250 * shank));
-			yposNode->setAttribute(chId, String(settings->electrodeMetadata[elec].ypos));
-		}
-
-		xmlNode->setAttribute("visualizationMode", (double)mode);
-		xmlNode->setAttribute("activityToView", (double)probeBrowser->activityToView);
-
-		xmlNode->setAttribute("isEnabled", bool(device->isEnabled()));
-	}*/
+		channelsNode->setAttribute("CH" + String(i), String(globalIndex));
+	}
 }
 
 void NeuropixelsV2eProbeInterface::loadParameters(XmlElement* xml)
 {
-	if (device != nullptr)
-	{
-		//auto npx = std::static_pointer_cast<Neuropixels2e>(device);
+	if (device == nullptr) return;
 
-		// TODO: load parameters, put them into device->settings, and then update the interface
-		//applyProbeSettings(device->settings.get(), false);
+	LOGD("Loading Neuropixels 2.0e settings.");
+
+	auto npx = std::static_pointer_cast<Neuropixels2e>(device);
+	auto settings = npx->settings[probeIndex].get();
+
+	XmlElement* xmlNode = nullptr;
+
+	for (auto* node : xml->getChildIterator())
+	{
+		if (node->hasTagName("PROBE" + String(probeIndex)))
+		{
+			xmlNode = node;
+			break;
+		}
 	}
+
+	if (xmlNode == nullptr)
+	{
+		LOGD("No PROBE" + String(probeIndex) + " element found");
+		return;
+	}
+
+	if (npx->getProbeSerialNumber(probeIndex) != 0 && xmlNode->getIntAttribute("probeSerialNumber") != npx->getProbeSerialNumber(probeIndex))
+	{
+		LOGC("Different serial numbers found. Current serial number is " + String(npx->getProbeSerialNumber(probeIndex)) + ", while the saved serial number is " + String(xmlNode->getIntAttribute("probeSerialNumber")) + ". Updating settings...");
+	}
+
+	npx->setGainCorrectionFile(probeIndex, xmlNode->getStringAttribute("gainCorrectionFile"));
+
+	XmlElement* probeViewerNode = xmlNode->getChildByName("PROBE_VIEWER");
+
+	if (probeViewerNode == nullptr)
+	{
+		LOGE("No PROBE_VIEWER element found.");
+		return;
+	}
+
+	probeBrowser->setZoomHeightAndOffset(probeViewerNode->getIntAttribute("zoomHeight"), probeViewerNode->getIntAttribute("zoomOffset"));
+
+	int idx = -1;
+
+	idx = getIndexOfComboBoxItem(referenceComboBox.get(), probeViewerNode->getStringAttribute("referenceChannel"));
+	if (idx == -1)
+	{
+		LOGE("No reference channel variable found.");
+	}
+	else
+		settings->referenceIndex = idx;
+
+	XmlElement* channelsNode = xmlNode->getChildByName("SELECTED_CHANNELS");
+
+	if (channelsNode == nullptr)
+	{
+		LOGE("No SELECTED_CHANNELS element found.");
+		return;
+	}
+
+	std::vector<int> selectedChannels{};
+	selectedChannels.reserve(npx->numberOfChannels);
+
+	for (int i = 0; i < npx->numberOfChannels; i++)
+	{
+		String chIdx = channelsNode->getStringAttribute("CH" + String(i), "");
+
+		if (chIdx == "")
+		{
+			LOGE("Channel #" + String(i) + " not found. Channel map will not be updated.");
+			return;
+		}
+
+		selectedChannels.emplace_back(std::stoi(chIdx.toStdString()));
+	}
+
+	std::sort(selectedChannels.begin(), selectedChannels.end());
+	auto last = std::unique(selectedChannels.begin(), selectedChannels.end());
+	selectedChannels.erase(last, selectedChannels.end());
+
+	if (selectedChannels.size() != npx->numberOfChannels)
+	{
+		LOGE("Invalid channel map. Wrong number of channels found. Channel map was not updated");
+		return;
+	}
+
+	selectElectrodes(selectedChannels);
+
+	updateSettings();
 }

--- a/Source/UI/NeuropixelsV2eProbeInterface.h
+++ b/Source/UI/NeuropixelsV2eProbeInterface.h
@@ -44,6 +44,7 @@ class NeuropixelsV2eProbeInterface : public SettingsInterface,
 {
 public:
 	friend class ProbeBrowser<Neuropixels2e::numberOfChannels, Neuropixels2e::numberOfElectrodes>;
+	friend class NeuropixelsV2eInterface;
 
 	NeuropixelsV2eProbeInterface(std::shared_ptr<Neuropixels2e> d, int ind, OnixSourceEditor* e, OnixSourceCanvas* c);
 
@@ -123,7 +124,7 @@ private:
 
 	std::vector<int> getSelectedElectrodes();
 
-	void setInterfaceEnabledState(bool enabledState);
+	void setInterfaceEnabledState(bool enabledState) override;
 
 	void checkForExistingChannelPreset();
 

--- a/Source/UI/NeuropixelsV2eProbeInterface.h
+++ b/Source/UI/NeuropixelsV2eProbeInterface.h
@@ -45,34 +45,29 @@ class NeuropixelsV2eProbeInterface : public SettingsInterface,
 public:
 	friend class ProbeBrowser<Neuropixels2e::numberOfChannels, Neuropixels2e::numberOfElectrodes>;
 
-	/** Constructor */
 	NeuropixelsV2eProbeInterface(std::shared_ptr<Neuropixels2e> d, int ind, OnixSourceEditor* e, OnixSourceCanvas* c);
 
-	/** Listener methods*/
 	void buttonClicked(Button*) override;
 	void comboBoxChanged(ComboBox*) override;
 
-	/** Disables buttons and starts animation if necessary */
 	void startAcquisition() override;
 
-	/** Enables buttons and start animation if necessary */
 	void stopAcquisition() override;
 
-	/** Settings-related functions*/
 	bool applyProbeSettings(ProbeSettings<Neuropixels2e::numberOfChannels, Neuropixels2e::numberOfElectrodes>* p, bool shouldUpdateProbe = true);
 
-	/** Save parameters to XML */
 	void saveParameters(XmlElement* xml) override;
 
-	/** Load parameters from XML */
 	void loadParameters(XmlElement* xml) override;
 
-	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override;
 
-	/** Set parameters */
+	void updateSettings() override;
+
 	void setReference(int index);
 	void selectElectrodes(std::vector<int> electrodes);
+
+	String getReferenceText() override { return referenceComboBox->getText(); }
 
 private:
 	XmlElement neuropix_info;
@@ -81,12 +76,10 @@ private:
 
 	const int probeIndex;
 
-	// Combo box - probe-specific settings
 	std::unique_ptr<ComboBox> electrodeConfigurationComboBox;
 	std::unique_ptr<ComboBox> referenceComboBox;
 	std::unique_ptr<ComboBox> activityViewComboBox;
 
-	// LABELS
 	std::unique_ptr<Label> deviceLabel;
 	std::unique_ptr<Label> infoLabel;
 	std::unique_ptr<Label> electrodesLabel;
@@ -132,7 +125,6 @@ private:
 
 	void setInterfaceEnabledState(bool enabledState);
 
-	/** Checks if the current channel map matches an existing channel preset, and updates the combo box if it does */
 	void checkForExistingChannelPreset();
 
 	JUCE_LEAK_DETECTOR(NeuropixelsV2eProbeInterface);

--- a/Source/UI/NeuropixelsV2eProbeInterface.h
+++ b/Source/UI/NeuropixelsV2eProbeInterface.h
@@ -79,32 +79,27 @@ private:
 
 	std::unique_ptr<ComboBox> electrodeConfigurationComboBox;
 	std::unique_ptr<ComboBox> referenceComboBox;
-	std::unique_ptr<ComboBox> activityViewComboBox;
 
 	std::unique_ptr<Label> deviceLabel;
 	std::unique_ptr<Label> infoLabel;
 	std::unique_ptr<Label> electrodesLabel;
 	std::unique_ptr<Label> electrodePresetLabel;
 	std::unique_ptr<Label> referenceLabel;
-	std::unique_ptr<Label> activityViewLabel;
 
 	std::unique_ptr<Label> gainCorrectionFileLabel;
+	std::unique_ptr<UtilityButton> gainCorrectionFileButton;
+	std::unique_ptr<FileChooser> gainCorrectionFileChooser;
+	std::unique_ptr<TextEditor> gainCorrectionFile;
 
-	// BUTTONS
 	std::unique_ptr<UtilityButton> enableButton;
 
 	std::unique_ptr<UtilityButton> enableViewButton;
 	std::unique_ptr<UtilityButton> referenceViewButton;
-	std::unique_ptr<UtilityButton> activityViewButton;
 
 	std::unique_ptr<DrawableRectangle> probeInterfaceRectangle;
 	std::unique_ptr<Label> probeInterfaceLabel;
 	std::unique_ptr<UtilityButton> loadJsonButton;
 	std::unique_ptr<UtilityButton> saveJsonButton;
-
-	std::unique_ptr<UtilityButton> gainCorrectionFileButton;
-	std::unique_ptr<FileChooser> gainCorrectionFileChooser;
-	std::unique_ptr<TextEditor> gainCorrectionFile;
 
 	std::unique_ptr<ProbeBrowser<Neuropixels2e::numberOfChannels, Neuropixels2e::numberOfElectrodes>> probeBrowser;
 
@@ -127,6 +122,8 @@ private:
 	void setInterfaceEnabledState(bool enabledState) override;
 
 	void checkForExistingChannelPreset();
+
+	int getIndexOfComboBoxItem(ComboBox* cb, String item);
 
 	JUCE_LEAK_DETECTOR(NeuropixelsV2eProbeInterface);
 };

--- a/Source/UI/OutputClockInterface.cpp
+++ b/Source/UI/OutputClockInterface.cpp
@@ -81,6 +81,21 @@ OutputClockInterface::OutputClockInterface(std::shared_ptr<OutputClock> d, OnixS
 	type = Type::OUTPUTCLOCK_SETTINGS_INTERFACE;
 }
 
+void OutputClockInterface::setInterfaceEnabledState(bool newState)
+{
+	if (frequencyHzValue != nullptr)
+		frequencyHzValue->setEnabled(newState);
+
+	if (dutyCycleValue != nullptr)
+		dutyCycleValue->setEnabled(newState);
+
+	if (delayValue != nullptr)
+		delayValue->setEnabled(newState);
+
+	if (gateRunButton != nullptr)
+		gateRunButton->setEnabled(newState);
+}
+
 void OutputClockInterface::updateSettings()
 {
 	if (device == nullptr) return;

--- a/Source/UI/OutputClockInterface.h
+++ b/Source/UI/OutputClockInterface.h
@@ -52,6 +52,8 @@ public:
 	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override {};
 
+	void updateSettings() override;
+
 	/** Listener methods*/
 	void buttonClicked(Button*) override;
 	void labelTextChanged(Label* l) override;

--- a/Source/UI/OutputClockInterface.h
+++ b/Source/UI/OutputClockInterface.h
@@ -37,28 +37,20 @@ public:
 
 	OutputClockInterface(std::shared_ptr<OutputClock> d, OnixSourceEditor* e, OnixSourceCanvas* c);
 
-	/** Disables buttons and starts animation if necessary */
-	void startAcquisition() override {};
-
-	/** Enables buttons and start animation if necessary */
-	void stopAcquisition() override {};
-
-	/** Save parameters to XML */
 	void saveParameters(XmlElement* xml) override;
 
-	/** Load parameters from XML */
 	void loadParameters(XmlElement* xml) override;
 
-	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override {};
 
 	void updateSettings() override;
 
-	/** Listener methods*/
 	void buttonClicked(Button*) override;
 	void labelTextChanged(Label* l) override;
 
 private:
+
+	void setInterfaceEnabledState(bool newState) override;
 
 	std::unique_ptr<Label> frequencyHzLabel;
 	std::unique_ptr<Label> frequencyHzValue;

--- a/Source/UI/OutputClockInterface.h
+++ b/Source/UI/OutputClockInterface.h
@@ -44,10 +44,10 @@ public:
 	void stopAcquisition() override {};
 
 	/** Save parameters to XML */
-	void saveParameters(XmlElement* xml) override {};
+	void saveParameters(XmlElement* xml) override;
 
 	/** Load parameters from XML */
-	void loadParameters(XmlElement* xml) override {};
+	void loadParameters(XmlElement* xml) override;
 
 	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override {};

--- a/Source/UI/PolledBno055Interface.cpp
+++ b/Source/UI/PolledBno055Interface.cpp
@@ -74,3 +74,9 @@ void PolledBno055Interface::updateSettings()
 
 	deviceEnableButton->setToggleState(device->isEnabled(), sendNotification);
 }
+
+void PolledBno055Interface::setInterfaceEnabledState(bool newState)
+{
+	if (deviceEnableButton != nullptr)
+		deviceEnableButton->setEnabled(newState);
+}

--- a/Source/UI/PolledBno055Interface.cpp
+++ b/Source/UI/PolledBno055Interface.cpp
@@ -67,3 +67,10 @@ void PolledBno055Interface::buttonClicked(Button* button)
 		CoreServices::updateSignalChain(editor);
 	}
 }
+
+void PolledBno055Interface::updateSettings()
+{
+	if (device == nullptr) return;
+
+	deviceEnableButton->setToggleState(device->isEnabled(), sendNotification);
+}

--- a/Source/UI/PolledBno055Interface.cpp
+++ b/Source/UI/PolledBno055Interface.cpp
@@ -80,3 +80,49 @@ void PolledBno055Interface::setInterfaceEnabledState(bool newState)
 	if (deviceEnableButton != nullptr)
 		deviceEnableButton->setEnabled(newState);
 }
+
+void PolledBno055Interface::saveParameters(XmlElement* xml)
+{
+	if (device == nullptr) return;
+
+	LOGD("Saving PolledBno055 settings.");
+
+	XmlElement* xmlNode = xml->createNewChildElement("POLLEDBNO055");
+
+	xmlNode->setAttribute("name", device->getName());
+	xmlNode->setAttribute("idx", (int)device->getDeviceIdx());
+
+	xmlNode->setAttribute("isEnabled", device->isEnabled());
+}
+
+void PolledBno055Interface::loadParameters(XmlElement* xml)
+{
+	if (device == nullptr) return;
+
+	LOGD("Loading PolledBno055 settings.");
+
+	XmlElement* xmlNode = nullptr;
+
+	for (auto* node : xml->getChildIterator())
+	{
+		if (node->hasTagName("POLLEDBNO055"))
+		{
+			if (node->getStringAttribute("name") == device->getName() &&
+				node->getIntAttribute("idx") == device->getDeviceIdx())
+			{
+				xmlNode = node;
+				break;
+			}
+		}
+	}
+
+	if (xmlNode == nullptr)
+	{
+		LOGD("No PolledBno055 element found.");
+		return;
+	}
+
+	device->setEnabled(xmlNode->getBoolAttribute("isEnabled"));
+
+	updateSettings();
+}

--- a/Source/UI/PolledBno055Interface.h
+++ b/Source/UI/PolledBno055Interface.h
@@ -35,10 +35,6 @@ class PolledBno055Interface : public SettingsInterface,
 public:
 	PolledBno055Interface(std::shared_ptr<PolledBno055> d, OnixSourceEditor* e, OnixSourceCanvas* c);
 
-	void startAcquisition() override {};
-
-	void stopAcquisition() override {};
-
 	void saveParameters(XmlElement* xml) override {};
 
 	void loadParameters(XmlElement* xml) override {};
@@ -48,6 +44,8 @@ public:
 	void buttonClicked(Button*) override;
 
 	void updateSettings() override;
+
+	void setInterfaceEnabledState(bool newState) override;
 
 private:
 

--- a/Source/UI/PolledBno055Interface.h
+++ b/Source/UI/PolledBno055Interface.h
@@ -33,26 +33,21 @@ class PolledBno055Interface : public SettingsInterface,
 	public Button::Listener
 {
 public:
-	/** Constructor */
 	PolledBno055Interface(std::shared_ptr<PolledBno055> d, OnixSourceEditor* e, OnixSourceCanvas* c);
 
-	/** Disables buttons and starts animation if necessary */
 	void startAcquisition() override {};
 
-	/** Enables buttons and start animation if necessary */
 	void stopAcquisition() override {};
 
-	/** Save parameters to XML */
 	void saveParameters(XmlElement* xml) override {};
 
-	/** Load parameters from XML */
 	void loadParameters(XmlElement* xml) override {};
 
-	/** Updates the info string on the right-hand side of the component */
 	void updateInfoString() override {};
 
-	/** Listener methods*/
 	void buttonClicked(Button*) override;
+
+	void updateSettings() override;
 
 private:
 

--- a/Source/UI/PolledBno055Interface.h
+++ b/Source/UI/PolledBno055Interface.h
@@ -35,9 +35,9 @@ class PolledBno055Interface : public SettingsInterface,
 public:
 	PolledBno055Interface(std::shared_ptr<PolledBno055> d, OnixSourceEditor* e, OnixSourceCanvas* c);
 
-	void saveParameters(XmlElement* xml) override {};
+	void saveParameters(XmlElement* xml) override;
 
-	void loadParameters(XmlElement* xml) override {};
+	void loadParameters(XmlElement* xml) override;
 
 	void updateInfoString() override {};
 

--- a/Source/UI/ProbeBrowser.h
+++ b/Source/UI/ProbeBrowser.h
@@ -566,7 +566,7 @@ public:
 		if (newHeight >= minZoomHeight && newHeight <= maxZoomHeight)
 		{
 			zoomHeight = newHeight;
-			zoomOffset = 0;
+			zoomOffset = newOffset;
 		}
 	}
 

--- a/Source/UI/SettingsInterface.h
+++ b/Source/UI/SettingsInterface.h
@@ -69,10 +69,10 @@ public:
     }
 
     /** Called when acquisition begins */
-    virtual void startAcquisition() = 0;
+    virtual void startAcquisition() { setInterfaceEnabledState(false); }
 
     /** Called when acquisition ends */
-    virtual void stopAcquisition() = 0;
+    virtual void stopAcquisition() { setInterfaceEnabledState(true); }
 
     /** Saves settings */
     virtual void saveParameters (XmlElement* xml) = 0;
@@ -86,19 +86,29 @@ public:
     /** Updates the UI elements based on the current device settings */
     virtual void updateSettings() = 0;
 
-    /** Default type */
-    Type type = Type::UNKNOWN_SETTINGS_INTERFACE;
+    std::shared_ptr<OnixDevice> getDevice() { return device; }
 
-    /** Pointer to the data source*/
-    std::shared_ptr<OnixDevice> device = nullptr;
+    void setDevice(std::shared_ptr<OnixDevice> dev) { device.reset(); device = dev; }
 
     VisualizationMode getMode() const { return mode; }
 
     virtual String getReferenceText() { return ""; }
 
 protected:
+
+    /** Pointer to the data source*/
+    std::shared_ptr<OnixDevice> device = nullptr;
+
+    Type type = Type::UNKNOWN_SETTINGS_INTERFACE;
+
     OnixSourceEditor* editor;
     OnixSourceCanvas* canvas;
 
     VisualizationMode mode = VisualizationMode::ENABLE_VIEW;
+
+private:
+
+    /** Enables or disables all UI elements that should not be changed during acquisition */
+    virtual void setInterfaceEnabledState(bool newState) = 0;
+
 };

--- a/Source/UI/SettingsInterface.h
+++ b/Source/UI/SettingsInterface.h
@@ -94,6 +94,8 @@ public:
 
     VisualizationMode getMode() const { return mode; }
 
+    virtual String getReferenceText() { return ""; }
+
 protected:
     OnixSourceEditor* editor;
     OnixSourceCanvas* canvas;

--- a/Source/UI/SettingsInterface.h
+++ b/Source/UI/SettingsInterface.h
@@ -83,7 +83,8 @@ public:
     /** Updates the string with info about the underlying data source*/
     virtual void updateInfoString() = 0;
 
-    virtual String getReferenceText() { return ""; }
+    /** Updates the UI elements based on the current device settings */
+    virtual void updateSettings() = 0;
 
     /** Default type */
     Type type = Type::UNKNOWN_SETTINGS_INTERFACE;


### PR DESCRIPTION
All UI elements are now saved to XML when manually saving a file (`Ctrl + S`) or when exiting the GUI normally (this creates a lastConfig.xml). Additionally, these same UI elements are now disabled during acquisition so that no settings can be accidentally changed in a vulnerable state.

The following is a list of settings interfaces that are finalized:
- AnalogIO
- DigitalIO
- OutputClock
- HarpSyncInput
- Bno055
- Neuropixels 1.0f
- Neuropixels 2.0e
- PolledBno055

Fixes #7 
Fixes #40 

Added a check for voltage override values when changing headstage selection, prompting the user if they want to keep the voltage or allow the automated voltage discovery algorithm to work.

Fixes #52 

Convert all timestamps from ticks to seconds before adding to the GUI buffer.

Fixes #53 

Add a port status indicator next to each port label that shows the connection status of that port

Fixes #51 