### PR TITLE
Update stream/channel identifiers

### DIFF
--- a/Source/Devices/AnalogIO.cpp
+++ b/Source/Devices/AnalogIO.cpp
@@ -28,14 +28,15 @@ AnalogIO::AnalogIO(String name, const oni_dev_idx_t deviceIdx_, std::shared_ptr<
 	StreamInfo analogInputStream = StreamInfo(
 		OnixDevice::createStreamName({ getHeadstageName(), name, "AnalogInput" }),
 		"Analog Input data",
-		"onix-analogio.data.input",
-		12,
+		getStreamIdentifier(),
+		getNumChannels(),
 		std::floor(AnalogIOFrequencyHz / framesToAverage),
 		"AnalogInput",
 		ContinuousChannel::Type::ADC,
 		20.0f / numberOfDivisions, // NB: +/- 10 Volts
 		"V",
-		{});
+		{},
+		{ "input" });
 	streamInfos.add(analogInputStream);
 
 	for (int i = 0; i < numFrames; i++)
@@ -63,7 +64,7 @@ bool AnalogIO::updateSettings()
 
 	for (int i = 0; i < numChannels; i += 1)
 	{
-		rc = deviceContext->writeRegister(deviceIdx, (oni_reg_addr_t)AnalogIORegisters::CH00_IN_RANGE + i, (oni_reg_val_t)channelVoltageRange[i]); 
+		rc = deviceContext->writeRegister(deviceIdx, (oni_reg_addr_t)AnalogIORegisters::CH00_IN_RANGE + i, (oni_reg_val_t)channelVoltageRange[i]);
 		if (rc != ONI_ESUCCESS) return false;
 	}
 

--- a/Source/Devices/Bno055.cpp
+++ b/Source/Devices/Bno055.cpp
@@ -27,70 +27,86 @@ Bno055::Bno055(String name, String headstageName, const oni_dev_idx_t deviceIdx_
 {
 	const float bitVolts = 1.0;
 
+	auto streamIdentifier = getStreamIdentifier();
+
 	String port = PortController::getPortName(PortController::getPortFromIndex(deviceIdx));
 	StreamInfo eulerAngleStream = StreamInfo(
 		OnixDevice::createStreamName({ port, getHeadstageName(), getName(), "Euler" }),
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Euler angle",
-		"onix-bno055.data.euler",
+		streamIdentifier,
 		3,
 		sampleRate,
 		"Euler",
 		ContinuousChannel::Type::AUX,
 		bitVolts,
 		"Degrees",
-		{ "Yaw", "Roll", "Pitch" });
+		{ "Yaw", "Roll", "Pitch" },
+		"euler",
+		{ "y", "r", "p" }
+	);
 	streamInfos.add(eulerAngleStream);
 
 	StreamInfo quaternionStream = StreamInfo(
 		OnixDevice::createStreamName({ port, getHeadstageName(), getName(), "Quaternion" }),
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Quaternion",
-		"onix-bno055.data.quat",
+		streamIdentifier,
 		4,
 		sampleRate,
 		"Quaternion",
 		ContinuousChannel::Type::AUX,
 		bitVolts,
 		"u",
-		{ "W", "X", "Y", "Z" });
+		{ "W", "X", "Y", "Z" },
+		"quaternion",
+		{ "w", "x", "y", "z" }
+	);
 	streamInfos.add(quaternionStream);
 
 	StreamInfo accelerationStream = StreamInfo(
 		OnixDevice::createStreamName({ port, getHeadstageName(), getName(), "Acceleration" }),
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Acceleration",
-		"onix-bno055.data.acc",
+		streamIdentifier,
 		3,
 		sampleRate,
 		"Acceleration",
 		ContinuousChannel::Type::AUX,
 		bitVolts,
 		"m / s ^ 2",
-		{ "X", "Y", "Z" });
+		{ "X", "Y", "Z" },
+		"acceleration",
+		{ "x","y","z" }
+	);
 	streamInfos.add(accelerationStream);
 
 	StreamInfo gravityStream = StreamInfo(
 		OnixDevice::createStreamName({ port, getHeadstageName(), getName(), "Gravity" }),
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Gravity",
-		"onix-bno055.data.grav",
+		streamIdentifier + ".gravity",
 		3,
 		sampleRate,
 		"Gravity",
 		ContinuousChannel::Type::AUX,
 		bitVolts,
 		"m/s^2",
-		{ "X", "Y", "Z" });
+		{ "X", "Y", "Z" },
+		"gravity",
+		{ "x", "y", "z" }
+	);
 	streamInfos.add(gravityStream);
 
 	StreamInfo temperatureStream = StreamInfo(
 		OnixDevice::createStreamName({ port, getHeadstageName(), getName(), "Temperature" }),
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Temperature",
-		"onix-bno055.data.temp",
+		streamIdentifier,
 		1,
 		sampleRate,
 		"Temperature",
 		ContinuousChannel::Type::AUX,
 		bitVolts,
 		"Celsius",
-		{ "" });
+		{ "" },
+		"temperature"
+	);
 	streamInfos.add(temperatureStream);
 
 	// TODO: Add calibration stream here?

--- a/Source/Devices/Bno055.cpp
+++ b/Source/Devices/Bno055.cpp
@@ -25,8 +25,6 @@
 Bno055::Bno055(String name, String headstageName, const oni_dev_idx_t deviceIdx_, std::shared_ptr<Onix1> ctx)
 	: OnixDevice(name, headstageName, OnixDeviceType::BNO, deviceIdx_, ctx)
 {
-	const float bitVolts = 1.0;
-
 	auto streamIdentifier = getStreamIdentifier();
 
 	String port = PortController::getPortName(PortController::getPortFromIndex(deviceIdx));
@@ -38,7 +36,7 @@ Bno055::Bno055(String name, String headstageName, const oni_dev_idx_t deviceIdx_
 		sampleRate,
 		"Euler",
 		ContinuousChannel::Type::AUX,
-		bitVolts,
+		eulerAngleScale,
 		"Degrees",
 		{ "Yaw", "Roll", "Pitch" },
 		"euler",
@@ -54,8 +52,8 @@ Bno055::Bno055(String name, String headstageName, const oni_dev_idx_t deviceIdx_
 		sampleRate,
 		"Quaternion",
 		ContinuousChannel::Type::AUX,
-		bitVolts,
-		"u",
+		quaternionScale,
+		"u", // NB: Quaternion data is unitless by definition
 		{ "W", "X", "Y", "Z" },
 		"quaternion",
 		{ "w", "x", "y", "z" }
@@ -70,8 +68,8 @@ Bno055::Bno055(String name, String headstageName, const oni_dev_idx_t deviceIdx_
 		sampleRate,
 		"Acceleration",
 		ContinuousChannel::Type::AUX,
-		bitVolts,
-		"m / s ^ 2",
+		accelerationScale,
+		"m/s^2",
 		{ "X", "Y", "Z" },
 		"acceleration",
 		{ "x","y","z" }
@@ -86,7 +84,7 @@ Bno055::Bno055(String name, String headstageName, const oni_dev_idx_t deviceIdx_
 		sampleRate,
 		"Gravity",
 		ContinuousChannel::Type::AUX,
-		bitVolts,
+		accelerationScale,
 		"m/s^2",
 		{ "X", "Y", "Z" },
 		"gravity",
@@ -102,7 +100,7 @@ Bno055::Bno055(String name, String headstageName, const oni_dev_idx_t deviceIdx_
 		sampleRate,
 		"Temperature",
 		ContinuousChannel::Type::AUX,
-		bitVolts,
+		1.0f,
 		"Celsius",
 		{ "" },
 		"temperature"
@@ -178,7 +176,7 @@ void Bno055::processFrames()
 		{
 			bnoSamples[currentFrame + channelOffset * numFrames] = float(*(dataPtr + dataOffset)) * eulerAngleScale;
 			dataOffset++;
-			channelOffset += 1;
+			channelOffset++;
 		}
 
 		// Quaternion
@@ -186,7 +184,7 @@ void Bno055::processFrames()
 		{
 			bnoSamples[currentFrame + channelOffset * numFrames] = float(*(dataPtr + dataOffset)) * quaternionScale;
 			dataOffset++;
-			channelOffset += 1;
+			channelOffset++;
 		}
 
 		// Acceleration
@@ -194,7 +192,7 @@ void Bno055::processFrames()
 		{
 			bnoSamples[currentFrame + channelOffset * numFrames] = float(*(dataPtr + dataOffset)) * accelerationScale;
 			dataOffset++;
-			channelOffset += 1;
+			channelOffset++;
 		}
 
 		// Gravity
@@ -202,7 +200,7 @@ void Bno055::processFrames()
 		{
 			bnoSamples[currentFrame + channelOffset * numFrames] = float(*(dataPtr + dataOffset)) * accelerationScale;
 			dataOffset++;
-			channelOffset += 1;
+			channelOffset++;
 		}
 
 		// Temperature

--- a/Source/Devices/DigitalIO.cpp
+++ b/Source/Devices/DigitalIO.cpp
@@ -59,7 +59,7 @@ EventChannel::Settings DigitalIO::getEventChannelSettings()
 		EventChannel::Type::TTL,
 		OnixDevice::createStreamName({getHeadstageName(), getName(), "Events"}),
 		"Digital inputs and breakout button states coming from a DigitalIO device",
-		"onix-digitalio.events",
+		getStreamIdentifier() + ".event.digital",
 		nullptr,
 		numButtons + numDigitalInputs
 	};

--- a/Source/Devices/HarpSyncInput.cpp
+++ b/Source/Devices/HarpSyncInput.cpp
@@ -30,14 +30,16 @@ HarpSyncInput::HarpSyncInput(String name, const oni_dev_idx_t deviceIdx_, std::s
 	StreamInfo harpTimeStream = StreamInfo(
 		OnixDevice::createStreamName({ getHeadstageName(), getName(), "HarpTime" }),
 		"Harp clock time corresponding to the local acquisition ONIX clock count",
-		"onix-harpsyncinput.data.harptime",
+		getStreamIdentifier(),
 		1,
 		1,
 		"HarpTime",
 		ContinuousChannel::Type::AUX,
 		1.0f,
 		"s",
-		{""});
+		{ "" },
+		"harptime"
+	);
 	streamInfos.add(harpTimeStream);
 
 	for (int i = 0; i < numFrames; i++)

--- a/Source/Devices/MemoryMonitor.cpp
+++ b/Source/Devices/MemoryMonitor.cpp
@@ -61,14 +61,16 @@ MemoryMonitor::MemoryMonitor(String name, const oni_dev_idx_t deviceIdx_, std::s
 	StreamInfo percentUsedStream = StreamInfo(
 		OnixDevice::createStreamName({ getHeadstageName(), getName(), "PercentUsed" }),
 		"Percent of available memory that is currently used",
-		"onix - memorymonitor.data.percentused",
+		getStreamIdentifier(),
 		1,
 		samplesPerSecond,
 		"Percent",
 		ContinuousChannel::Type::AUX,
 		1.0f,
 		"%",
-		{ "" });
+		{ "" },
+		"percent"
+	);
 	streamInfos.add(percentUsedStream);
 
 	for (int i = 0; i < numFrames; i++)

--- a/Source/Devices/Neuropixels2e.cpp
+++ b/Source/Devices/Neuropixels2e.cpp
@@ -44,14 +44,16 @@ void Neuropixels2e::createDataStream(int n)
 	StreamInfo apStream = StreamInfo(
 		OnixDevice::createStreamName({ PortController::getPortName(PortController::getPortFromIndex(deviceIdx)), getHeadstageName(), "Probe" + String(n) }),
 		"Neuropixels 2.0 data stream",
-		"onix-neuropixels2.data",
+		getStreamIdentifier(),
 		numberOfChannels,
 		sampleRate,
 		"CH",
 		ContinuousChannel::Type::ELECTRODE,
 		0.195f,
 		CharPointer_UTF8("\xc2\xb5V"),
-		{});
+		{},
+		"ap"
+	);
 	streamInfos.add(apStream);
 }
 

--- a/Source/Devices/Neuropixels_1.cpp
+++ b/Source/Devices/Neuropixels_1.cpp
@@ -174,30 +174,36 @@ Neuropixels_1::Neuropixels_1(String name, const oni_dev_idx_t deviceIdx_, std::s
 	INeuropixel(NeuropixelsV1fValues::numberOfSettings, NeuropixelsV1fValues::numberOfShanks)
 {
 	String port = PortController::getPortName(PortController::getPortFromIndex(deviceIdx));
+	auto streamIdentifier = getStreamIdentifier();
+
 	StreamInfo apStream = StreamInfo(
 		OnixDevice::createStreamName({ port, getHeadstageName(), getName(), "AP" }),
 		"Neuropixels 1.0 AP band data stream",
-		"onix-neuropixels1.data.ap",
+		streamIdentifier,
 		numberOfChannels,
 		apSampleRate,
 		"AP",
 		ContinuousChannel::Type::ELECTRODE,
 		0.195f,
 		CharPointer_UTF8("\xc2\xb5V"),
-		{});
+		{},
+		"ap"
+	);
 	streamInfos.add(apStream);
 
 	StreamInfo lfpStream = StreamInfo(
 		OnixDevice::createStreamName({ port, getHeadstageName(), getName(), "LFP" }),
 		"Neuropixels 1.0 LFP band data stream",
-		"onix-neuropixels1.data.lfp",
+		streamIdentifier,
 		numberOfChannels,
 		lfpSampleRate,
 		"LFP",
 		ContinuousChannel::Type::ELECTRODE,
 		0.195f,
 		CharPointer_UTF8("\xc2\xb5V"),
-		{});
+		{},
+		"lfp"
+	);
 	streamInfos.add(lfpStream);
 
 	defineMetadata(settings[0].get());

--- a/Source/Devices/PolledBno055.cpp
+++ b/Source/Devices/PolledBno055.cpp
@@ -28,83 +28,101 @@ PolledBno055::PolledBno055(String name, String headstageName, const oni_dev_idx_
 {
 	const float bitVolts = 1.0;
 
+	auto streamIdentifier = getStreamIdentifier();
+
 	String port = PortController::getPortName(PortController::getPortFromIndex(deviceIdx));
 	StreamInfo eulerAngleStream = StreamInfo(
 		OnixDevice::createStreamName({ port, getHeadstageName(), getName(), "Euler" }),
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Euler angle",
-		"onix-bno055.data.euler",
+		streamIdentifier,
 		3,
 		sampleRate,
 		"Euler",
 		ContinuousChannel::Type::AUX,
 		bitVolts,
 		"Degrees",
-		{ "Yaw", "Roll", "Pitch" });
+		{ "Yaw", "Roll", "Pitch" },
+		"euler",
+		{ "y", "r", "p" }
+	);
 	streamInfos.add(eulerAngleStream);
 	
 	StreamInfo quaternionStream = StreamInfo(
 		OnixDevice::createStreamName({ port, getHeadstageName(), getName(), "Quaternion" }),
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Quaternion",
-		"onix-bno055.data.quat",
+		streamIdentifier,
 		4,
 		sampleRate,
 		"Quaternion",
 		ContinuousChannel::Type::AUX,
 		bitVolts,
 		"",
-		{ "W", "X", "Y", "Z" });
+		{ "W", "X", "Y", "Z" },
+		"quaternion",
+		{ "w", "x", "y", "z" }
+	);
 	streamInfos.add(quaternionStream);
 
 	StreamInfo accelerationStream = StreamInfo(
 		OnixDevice::createStreamName({ port, getHeadstageName(), getName(), "Acceleration" }),
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Acceleration",
-		"onix-bno055.data.acc",
+		streamIdentifier,
 		3,
 		sampleRate,
 		"Acceleration",
 		ContinuousChannel::Type::AUX,
 		bitVolts,
 		"m / s ^ 2",
-		{ "X", "Y", "Z" });
+		{ "X", "Y", "Z" },
+		"acceleration",
+		{ "x","y","z" }
+	);
 	streamInfos.add(accelerationStream);
 
 	StreamInfo gravityStream = StreamInfo(
 		OnixDevice::createStreamName({ port, getHeadstageName(), getName(), "Gravity" }),
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Gravity",
-		"onix-bno055.data.grav",
+		streamIdentifier,
 		3,
 		sampleRate,
 		"Gravity",
 		ContinuousChannel::Type::AUX,
 		bitVolts,
 		"m/s^2",
-		{ "X", "Y", "Z" });
+		{ "X", "Y", "Z" },
+		"gravity",
+		{ "x", "y", "z" }
+	);
 	streamInfos.add(gravityStream);
 
 	StreamInfo temperatureStream = StreamInfo(
 		OnixDevice::createStreamName({ port, getHeadstageName(), getName(), "Temperature" }),
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Temperature",
-		"onix-bno055.data.temp",
+		streamIdentifier,
 		1,
 		sampleRate,
 		"Temperature",
 		ContinuousChannel::Type::AUX,
 		bitVolts,
 		"Celsius",
-		{ "" });
+		{ "" },
+		"temperature"
+	);
 	streamInfos.add(temperatureStream);
 
 	StreamInfo calibrationStatusStream = StreamInfo(
 		OnixDevice::createStreamName({ port, getHeadstageName(), getName(), "Calibration" }),
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Calibration",
-		"onix-bno055.data.cal",
+		streamIdentifier,
 		1,
 		sampleRate,
 		"Calibration",
 		ContinuousChannel::Type::AUX,
 		bitVolts,
 		"",
-		{ "" });
+		{ "" },
+		"calibration"
+	);
 	streamInfos.add(calibrationStatusStream);
 
 	for (int i = 0; i < numFrames; i++)

--- a/Source/Devices/PolledBno055.cpp
+++ b/Source/Devices/PolledBno055.cpp
@@ -26,8 +26,6 @@ PolledBno055::PolledBno055(String name, String headstageName, const oni_dev_idx_
 	: OnixDevice(name, headstageName, OnixDeviceType::POLLEDBNO, deviceIdx_, ctx),
 	I2CRegisterContext(Bno055Address, deviceIdx_, ctx)
 {
-	const float bitVolts = 1.0;
-
 	auto streamIdentifier = getStreamIdentifier();
 
 	String port = PortController::getPortName(PortController::getPortFromIndex(deviceIdx));
@@ -39,7 +37,7 @@ PolledBno055::PolledBno055(String name, String headstageName, const oni_dev_idx_
 		sampleRate,
 		"Euler",
 		ContinuousChannel::Type::AUX,
-		bitVolts,
+		eulerAngleScale,
 		"Degrees",
 		{ "Yaw", "Roll", "Pitch" },
 		"euler",
@@ -55,7 +53,7 @@ PolledBno055::PolledBno055(String name, String headstageName, const oni_dev_idx_
 		sampleRate,
 		"Quaternion",
 		ContinuousChannel::Type::AUX,
-		bitVolts,
+		quaternionScale,
 		"",
 		{ "W", "X", "Y", "Z" },
 		"quaternion",
@@ -71,7 +69,7 @@ PolledBno055::PolledBno055(String name, String headstageName, const oni_dev_idx_
 		sampleRate,
 		"Acceleration",
 		ContinuousChannel::Type::AUX,
-		bitVolts,
+		accelerationScale,
 		"m / s ^ 2",
 		{ "X", "Y", "Z" },
 		"acceleration",
@@ -87,7 +85,7 @@ PolledBno055::PolledBno055(String name, String headstageName, const oni_dev_idx_
 		sampleRate,
 		"Gravity",
 		ContinuousChannel::Type::AUX,
-		bitVolts,
+		accelerationScale,
 		"m/s^2",
 		{ "X", "Y", "Z" },
 		"gravity",
@@ -103,7 +101,7 @@ PolledBno055::PolledBno055(String name, String headstageName, const oni_dev_idx_
 		sampleRate,
 		"Temperature",
 		ContinuousChannel::Type::AUX,
-		bitVolts,
+		1.0f,
 		"Celsius",
 		{ "" },
 		"temperature"
@@ -118,7 +116,7 @@ PolledBno055::PolledBno055(String name, String headstageName, const oni_dev_idx_
 		sampleRate,
 		"Calibration",
 		ContinuousChannel::Type::AUX,
-		bitVolts,
+		1.0f,
 		"",
 		{ "" },
 		"calibration"

--- a/Source/Devices/PolledBno055.cpp
+++ b/Source/Devices/PolledBno055.cpp
@@ -288,5 +288,14 @@ void PolledBno055::hiResTimerCallback()
 		bnoBuffer->addToBuffer(bnoSamples.data(), sampleNumbers, bnoTimestamps, eventCodes, numFrames);
 		currentFrame = 0;
 	}
+}
 
+void PolledBno055::setBnoAxisMap(Bno055AxisMap map)
+{
+	axisMap = map;
+}
+
+void PolledBno055::setBnoAxisSign(Bno055AxisSign sign)
+{
+	axisSign = sign;
 }

--- a/Source/Devices/PolledBno055.h
+++ b/Source/Devices/PolledBno055.h
@@ -62,6 +62,28 @@ public:
 
 	void hiResTimerCallback() override;
 
+	enum class Bno055AxisMap : uint32_t
+	{
+		XYZ = 0b00100100, // Specifies that X->X', Y->Y', Z->Z' (chip default). 
+		XZY = 0b00011000, // Specifies that X->X', Z->Y', Y->Z'
+		YXZ = 0b00100001, // Specifies that Y->X', X->Y', Z->Z'
+		YZX = 0b00001001, // Specifies that Y->X', Z->Y', X->Z'
+		ZXY = 0b00010010, // Specifies that Z->X', X->Y', Y->Z'
+		ZYX = 0b00000110, // Specifies that Z->X', Y->Y', X->Z'
+	};
+
+	enum class Bno055AxisSign : uint32_t
+	{
+		Default = 0b00000000, // Specifies that all axes are positive (chip default).
+		MirrorZ = 0b00000001, // Specifies that Z' axis should be mirrored.
+		MirrorY = 0b00000010, // Specifies that Y' axis should be mirrored.
+		MirrorX = 0b00000100, // Specifies that X' axis should be mirrored.
+		MirrorXAndY = 0b00000110, // X' and Y' are mirrored
+	};
+
+	void setBnoAxisMap(Bno055AxisMap map);
+	void setBnoAxisSign(Bno055AxisSign sign);
+
 private:
 
 	DataBuffer* bnoBuffer;
@@ -79,24 +101,6 @@ private:
 
 	std::unique_ptr<I2CRegisterContext> deserializer;
 
-	enum class Bno055AxisMap : uint32_t
-	{
-		XYZ = 0b00100100, // Specifies that X->X', Y->Y', Z->Z' (chip default). 
-		XZY = 0b00011000, // Specifies that X->X', Z->Y', Y->Z'
-		YXZ = 0b00100001, // Specifies that Y->X', X->Y', Z->Z'
-		YZX = 0b00001001, // Specifies that Y->X', Z->Y', X->Z'
-		ZXY = 0b00010010, // Specifies that Z->X', X->Y', Y->Z'
-		ZYX = 0b00000110, // Specifies that Z->X', Y->Y', X->Z'
-	};
-
-	enum class Bno055AxisSign : uint32_t
-	{
-		Default = 0b00000000, // Specifies that all axes are positive (chip default).
-		MirrorZ = 0b00000001, // Specifies that Z' axis should be mirrored.
-		MirrorY = 0b00000010, // Specifies that Y' axis should be mirrored.
-		MirrorX = 0b00000100, // Specifies that X' axis should be mirrored.
-	};
-
 	enum class PolledBno055Registers : int32_t
 	{
 		EulerAngle = 0x1, // Specifies that the Euler angles will be polled.
@@ -108,8 +112,8 @@ private:
 		All = EulerAngle | Quaternion | Acceleration | Gravity | Temperature | Calibration, // Specifies that all sensor measurements and calibration status will be polled.
 	};
 
-	const Bno055AxisMap axisMap = Bno055AxisMap::XYZ;
-	const Bno055AxisSign axisSign = Bno055AxisSign::Default;
+	Bno055AxisMap axisMap = Bno055AxisMap::XYZ;
+	Bno055AxisSign axisSign = Bno055AxisSign::Default;
 
 	static const int numberOfChannels = 3 + 3 + 4 + 3 + 1 + 1;
 	static constexpr double sampleRate = 30.0;

--- a/Source/Devices/PortController.cpp
+++ b/Source/Devices/PortController.cpp
@@ -66,8 +66,8 @@ void PortController::processFrames()
 
 		int dataOffset = 8;
 
-		uint32_t code = (uint32_t) *(dataPtr + dataOffset);
-		uint32_t data = (uint32_t) *(dataPtr + dataOffset + 1);
+		uint32_t code = (uint32_t) * (dataPtr + dataOffset);
+		uint32_t data = (uint32_t) * (dataPtr + dataOffset + 1);
 
 		errorFlag = errorFlag || ((uint32_t)data & LINKSTATE_SL) == 0;
 
@@ -115,19 +115,29 @@ bool PortController::configureVoltage(double voltage)
 {
 	if (voltage == defaultVoltage)
 	{
-		if (discoveryParameters == DiscoveryParameters() || discoveryParameters.voltageIncrement <= 0) 
+		if (discoveryParameters == DiscoveryParameters() || discoveryParameters.voltageIncrement <= 0)
 			return false;
 
 		ConfigureVoltageWithProgressBar progressBar = ConfigureVoltageWithProgressBar(discoveryParameters, this);
 		progressBar.runThread();
 
-		return progressBar.getResult();
+		bool result = progressBar.getResult();
+
+		if (!result)
+			setVoltageOverride(0, false);
+
+		return result;
 	}
 	else if (voltage >= 0.0 && voltage <= 7.0)
 	{
 		setVoltage(voltage);
 
-		return checkLinkState();
+		bool result = checkLinkState();
+
+		if (!result)
+			setVoltageOverride(0, false);
+
+		return result;
 	}
 
 	return false;

--- a/Source/Onix1.h
+++ b/Source/Onix1.h
@@ -88,7 +88,7 @@ public:
 
 	int issueReset() { int val = 1; int rc = setOption(ONI_OPT_RESET, val); return rc; }
 
-	String getVersion() { return String(major) + "." + String(minor) + "." + String(patch); }
+	std::string getVersion() { return std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch); }
 
 private:
 

--- a/Source/OnixDevice.cpp
+++ b/Source/OnixDevice.cpp
@@ -50,3 +50,59 @@ oni_dev_idx_t OnixDevice::getDeviceIndexFromPassthroughIndex(oni_dev_idx_t passt
 
 	return idx;
 }
+
+OnixDeviceType OnixDevice::getDeviceType() const
+{
+	return type;
+}
+
+String OnixDevice::getStreamIdentifier()
+{
+	String streamIdentifier = "onix.";
+
+	// Insert the headstage or breakout board
+	if (getHeadstageName() == NEUROPIXELSV1F_HEADSTAGE_NAME)
+	{
+		streamIdentifier += "npx1f.";
+	}
+	else if (getHeadstageName() == NEUROPIXELSV2E_HEADSTAGE_NAME)
+	{
+		streamIdentifier += "npx2e.";
+	}
+	else if (getHeadstageName() == BREAKOUT_BOARD_NAME)
+	{
+		streamIdentifier += "breakout.";
+	}
+
+	// Insert the device
+	if (getDeviceType() == OnixDeviceType::ANALOGIO)
+	{
+		streamIdentifier += "analogio";
+	}
+	else if (getDeviceType() == OnixDeviceType::BNO || getDeviceType() == OnixDeviceType::POLLEDBNO)
+	{
+		streamIdentifier += "9dof";
+	}
+	else if (getDeviceType() == OnixDeviceType::DIGITALIO)
+	{
+		streamIdentifier += "digitalio";
+	}
+	else if (getDeviceType() == OnixDeviceType::HARPSYNCINPUT)
+	{
+		streamIdentifier += "harp";
+	}
+	else if (getDeviceType() == OnixDeviceType::MEMORYMONITOR)
+	{
+		streamIdentifier += "memory";
+	}
+	else if (getDeviceType() == OnixDeviceType::NEUROPIXELS_1)
+	{
+		streamIdentifier += "npx1f";
+	}
+	else if (getDeviceType() == OnixDeviceType::NEUROPIXELSV2E)
+	{
+		streamIdentifier += "npx2e";
+	}
+
+	return streamIdentifier;
+}

--- a/Source/OnixDevice.h
+++ b/Source/OnixDevice.h
@@ -83,7 +83,7 @@ public:
 			m_channelNameSuffixes.clear();
 			m_channelNameSuffixes.ensureStorageAllocated(numChannels);
 
-			for (int i = 0; i < m_numChannels; i += 1)
+			for (int i = 0; i < m_numChannels; i++)
 			{
 				m_channelNameSuffixes.add(String(i + 1));
 			}
@@ -105,7 +105,7 @@ public:
 				m_channelIdentifierSubTypes.clear();
 				m_channelIdentifierSubTypes.ensureStorageAllocated(numChannels);
 
-				for (int i = 0; i < m_numChannels; i += 1)
+				for (int i = 0; i < m_numChannels; i++)
 				{
 					m_channelIdentifierSubTypes.add(String(i + 1));
 				}

--- a/Source/OnixSource.cpp
+++ b/Source/OnixSource.cpp
@@ -235,6 +235,9 @@ void OnixSource::initializeDevices(bool updateStreamInfo)
 					continue;
 				}
 
+				polledBno->setBnoAxisMap(PolledBno055::Bno055AxisMap::YZX);
+				polledBno->setBnoAxisSign(PolledBno055::Bno055AxisSign::MirrorXAndY);
+
 				sources.emplace_back(polledBno);
 
 				headstages.insert({ PortController::getOffsetFromIndex(index), NEUROPIXELSV2E_HEADSTAGE_NAME });

--- a/Source/OnixSource.cpp
+++ b/Source/OnixSource.cpp
@@ -404,7 +404,7 @@ std::shared_ptr<OnixDevice> OnixSource::getDevice(OnixDeviceType type)
 {
 	for (const auto& device : sources)
 	{
-		if (device->type == type) return device;
+		if (device->getDeviceType() == type) return device;
 	}
 
 	return nullptr;
@@ -416,9 +416,9 @@ std::map<int, OnixDeviceType> OnixSource::createDeviceMap(OnixDeviceVector devic
 
 	for (const auto& device : devices)
 	{
-		if (filterDevices && (device->type == OnixDeviceType::HEARTBEAT || device->type == OnixDeviceType::MEMORYMONITOR)) continue;
+		if (filterDevices && (device->getDeviceType() == OnixDeviceType::HEARTBEAT || device->getDeviceType() == OnixDeviceType::MEMORYMONITOR)) continue;
 
-		deviceMap.insert({ device->getDeviceIdx(), device->type });
+		deviceMap.insert({ device->getDeviceIdx(), device->getDeviceType() });
 	}
 
 	return deviceMap;
@@ -543,7 +543,7 @@ void OnixSource::updateSettings(OwnedArray<ContinuousChannel>* continuousChannel
 		{
 			if (!source->isEnabled()) continue;
 
-			if (source->type == OnixDeviceType::NEUROPIXELS_1)
+			if (source->getDeviceType() == OnixDeviceType::NEUROPIXELS_1)
 			{
 				DeviceInfo::Settings deviceSettings{
 					source->getName(),
@@ -557,7 +557,7 @@ void OnixSource::updateSettings(OwnedArray<ContinuousChannel>* continuousChannel
 
 				addIndividualStreams(source->streamInfos, dataStreams, deviceInfos, continuousChannels);
 			}
-			else if (source->type == OnixDeviceType::BNO || source->type == OnixDeviceType::POLLEDBNO)
+			else if (source->getDeviceType() == OnixDeviceType::BNO || source->getDeviceType() == OnixDeviceType::POLLEDBNO)
 			{
 				DeviceInfo::Settings deviceSettings{
 					source->getName(),
@@ -572,13 +572,13 @@ void OnixSource::updateSettings(OwnedArray<ContinuousChannel>* continuousChannel
 				DataStream::Settings dataStreamSettings{
 					OnixDevice::createStreamName({PortController::getPortName(PortController::getPortFromIndex(source->getDeviceIdx())), source->getHeadstageName(), source->getName()}),
 					"Continuous data from a Bno055 9-axis IMU",
-					"onix-bno055.data",
+					source->getStreamIdentifier(),
 					source->streamInfos[0].getSampleRate()
 				};
 
 				addCombinedStreams(dataStreamSettings, source->streamInfos, dataStreams, deviceInfos, continuousChannels);
 			}
-			else if (source->type == OnixDeviceType::NEUROPIXELSV2E)
+			else if (source->getDeviceType() == OnixDeviceType::NEUROPIXELSV2E)
 			{
 				DeviceInfo::Settings deviceSettings{
 					source->getName(),
@@ -592,7 +592,7 @@ void OnixSource::updateSettings(OwnedArray<ContinuousChannel>* continuousChannel
 
 				addIndividualStreams(source->streamInfos, dataStreams, deviceInfos, continuousChannels);
 			}
-			else if (source->type == OnixDeviceType::MEMORYMONITOR)
+			else if (source->getDeviceType() == OnixDeviceType::MEMORYMONITOR)
 			{
 				DeviceInfo::Settings deviceSettings{
 					source->getName(),
@@ -615,7 +615,7 @@ void OnixSource::updateSettings(OwnedArray<ContinuousChannel>* continuousChannel
 					std::static_pointer_cast<MemoryMonitor>(source)->setDigitalIO(digitalIO);
 				}
 			}
-			else if (source->type == OnixDeviceType::ANALOGIO)
+			else if (source->getDeviceType() == OnixDeviceType::ANALOGIO)
 			{
 				DeviceInfo::Settings deviceSettings{
 					source->getName(),
@@ -629,7 +629,7 @@ void OnixSource::updateSettings(OwnedArray<ContinuousChannel>* continuousChannel
 
 				addIndividualStreams(source->streamInfos, dataStreams, deviceInfos, continuousChannels);
 			}
-			else if (source->type == OnixDeviceType::HARPSYNCINPUT)
+			else if (source->getDeviceType() == OnixDeviceType::HARPSYNCINPUT)
 			{
 				DeviceInfo::Settings deviceSettings{
 					source->getName(),
@@ -663,9 +663,9 @@ void OnixSource::addCombinedStreams(DataStream::Settings dataStreamSettings,
 		{
 			ContinuousChannel::Settings channelSettings{
 				streamInfo.getChannelType(),
-				streamInfo.getChannelPrefix() + streamInfo.getSuffixes()[chan],
+				streamInfo.getChannelPrefix() + streamInfo.getChannelNameSuffixes()[chan],
 				streamInfo.getDescription(),
-				streamInfo.getIdentifier(),
+				createContinuousChannelIdentifier(streamInfo, chan),
 				streamInfo.getBitVolts(),
 				stream
 			};
@@ -686,7 +686,7 @@ void OnixSource::addIndividualStreams(Array<StreamInfo> streamInfos,
 		{
 			streamInfo.getName(),
 			streamInfo.getDescription(),
-			streamInfo.getIdentifier(),
+			streamInfo.getStreamIdentifier(),
 			streamInfo.getSampleRate()
 		};
 
@@ -694,14 +694,16 @@ void OnixSource::addIndividualStreams(Array<StreamInfo> streamInfos,
 		dataStreams->add(stream);
 		stream->device = deviceInfos->getLast();
 
+		auto suffixes = streamInfo.getChannelNameSuffixes();
+
 		// Add continuous channels
 		for (int chan = 0; chan < streamInfo.getNumChannels(); chan++)
 		{
 			ContinuousChannel::Settings channelSettings{
 				streamInfo.getChannelType(),
-				streamInfo.getChannelPrefix() + streamInfo.getSuffixes()[chan],
+				streamInfo.getChannelPrefix() + suffixes[chan],
 				streamInfo.getDescription(),
-				streamInfo.getIdentifier(),
+				createContinuousChannelIdentifier(streamInfo, chan),
 				streamInfo.getBitVolts(),
 				stream
 			};
@@ -709,6 +711,21 @@ void OnixSource::addIndividualStreams(Array<StreamInfo> streamInfos,
 			continuousChannels->getLast()->setUnits(streamInfo.getUnits());
 		}
 	}
+}
+
+String OnixSource::createContinuousChannelIdentifier(StreamInfo streamInfo, int channelNumber)
+{
+	auto dataType = streamInfo.getChannelIdentifierDataType();
+	auto subTypes = streamInfo.getChannelIdentifierSubTypes();
+
+	auto channelIdentifier = streamInfo.getStreamIdentifier() + ".continuous." + dataType;
+
+	if (subTypes.size() == streamInfo.getNumChannels())
+		channelIdentifier += "." + subTypes[channelNumber];
+	else if (subTypes.size() == 1)
+		channelIdentifier += "." + subTypes[0];
+
+	return channelIdentifier;
 }
 
 bool OnixSource::isDevicesReady()

--- a/Source/OnixSource.h
+++ b/Source/OnixSource.h
@@ -150,5 +150,7 @@ private:
 
 	void addCombinedStreams(DataStream::Settings, Array<StreamInfo>, OwnedArray<DataStream>*, OwnedArray<DeviceInfo>*, OwnedArray<ContinuousChannel>*);
 
+	String createContinuousChannelIdentifier(StreamInfo streamInfo, int channelNumber);
+
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OnixSource);
 };

--- a/Source/OnixSourceCanvas.cpp
+++ b/Source/OnixSourceCanvas.cpp
@@ -91,42 +91,42 @@ void OnixSourceCanvas::populateSourceTabs(CustomTabComponent* tab, OnixDeviceVec
 
 	for (const auto& device : devices)
 	{
-		if (device->type == OnixDeviceType::NEUROPIXELS_1)
+		if (device->getDeviceType() == OnixDeviceType::NEUROPIXELS_1)
 		{
 			auto neuropixInterface = std::make_shared<NeuropixV1Interface>(std::static_pointer_cast<Neuropixels_1>(device), editor, this);
 			addInterfaceToTab(device->getName(), tab, neuropixInterface);
 		}
-		else if (device->type == OnixDeviceType::BNO)
+		else if (device->getDeviceType() == OnixDeviceType::BNO)
 		{
 			auto bno055Interface = std::make_shared<Bno055Interface>(std::static_pointer_cast<Bno055>(device), editor, this);
 			addInterfaceToTab(device->getName(), tab, bno055Interface);
 		}
-		else if (device->type == OnixDeviceType::OUTPUTCLOCK)
+		else if (device->getDeviceType() == OnixDeviceType::OUTPUTCLOCK)
 		{
 			auto outputClockInterface = std::make_shared<OutputClockInterface>(std::static_pointer_cast<OutputClock>(device), editor, this);
 			addInterfaceToTab(device->getName(), tab, outputClockInterface);
 		}
-		else if (device->type == OnixDeviceType::HARPSYNCINPUT)
+		else if (device->getDeviceType() == OnixDeviceType::HARPSYNCINPUT)
 		{
 			auto harpSyncInputInterface = std::make_shared<HarpSyncInputInterface>(std::static_pointer_cast<HarpSyncInput>(device), editor, this);
 			addInterfaceToTab(device->getName(), tab, harpSyncInputInterface);
 		}
-		else if (device->type == OnixDeviceType::ANALOGIO)
+		else if (device->getDeviceType() == OnixDeviceType::ANALOGIO)
 		{
 			auto analogIOInterface = std::make_shared<AnalogIOInterface>(std::static_pointer_cast<AnalogIO>(device), editor, this);
 			addInterfaceToTab(device->getName(), tab, analogIOInterface);
 		}
-		else if (device->type == OnixDeviceType::DIGITALIO)
+		else if (device->getDeviceType() == OnixDeviceType::DIGITALIO)
 		{
 			auto digitalIOInterface = std::make_shared<DigitalIOInterface>(std::static_pointer_cast<DigitalIO>(device), editor, this);
 			addInterfaceToTab(device->getName(), tab, digitalIOInterface);
 		}
-		else if (device->type == OnixDeviceType::NEUROPIXELSV2E)
+		else if (device->getDeviceType() == OnixDeviceType::NEUROPIXELSV2E)
 		{
 			auto npxv2eInterface = std::make_shared<NeuropixelsV2eInterface>(std::static_pointer_cast<Neuropixels2e>(device), editor, this);
 			addInterfaceToTab(device->getHeadstageName(), tab, npxv2eInterface);
 		}
-		else if (device->type == OnixDeviceType::POLLEDBNO)
+		else if (device->getDeviceType() == OnixDeviceType::POLLEDBNO)
 		{
 			auto polledBnoInterface = std::make_shared<PolledBno055Interface>(std::static_pointer_cast<PolledBno055>(device), editor, this);
 			addInterfaceToTab(device->getName(), tab, polledBnoInterface);
@@ -168,13 +168,13 @@ void OnixSourceCanvas::updateSettingsInterfaceDataSource(std::shared_ptr<OnixDev
 
 	if (ind == -1)
 	{
-		if (device->type != OnixDeviceType::MEMORYMONITOR && device->type != OnixDeviceType::HEARTBEAT)
+		if (device->getDeviceType() != OnixDeviceType::MEMORYMONITOR && device->getDeviceType() != OnixDeviceType::HEARTBEAT)
 			LOGD("Unable to match " + device->getName() + " to an open tab.");
 
 		return;
 	}
 
-	if (device->type == OnixDeviceType::NEUROPIXELS_1)
+	if (device->getDeviceType() == OnixDeviceType::NEUROPIXELS_1)
 	{
 		auto npx1Found = std::static_pointer_cast<Neuropixels_1>(device);
 		auto npx1Selected = std::static_pointer_cast<Neuropixels_1>(settingsInterfaces[ind]->device);
@@ -183,7 +183,7 @@ void OnixSourceCanvas::updateSettingsInterfaceDataSource(std::shared_ptr<OnixDev
 		npx1Found->gainCalibrationFilePath = npx1Selected->gainCalibrationFilePath;
 		npx1Found->setCorrectOffset(npx1Selected->getCorrectOffset());
 	}
-	else if (device->type == OnixDeviceType::OUTPUTCLOCK)
+	else if (device->getDeviceType() == OnixDeviceType::OUTPUTCLOCK)
 	{
 		auto outputClockFound = std::static_pointer_cast<OutputClock>(device);
 		auto outputClockSelected = std::static_pointer_cast<OutputClock>(settingsInterfaces[ind]->device);
@@ -192,7 +192,7 @@ void OnixSourceCanvas::updateSettingsInterfaceDataSource(std::shared_ptr<OnixDev
 		outputClockFound->setFrequencyHz(outputClockSelected->getFrequencyHz());
 		outputClockFound->setGateRun(outputClockSelected->getGateRun());
 	}
-	else if (device->type == OnixDeviceType::ANALOGIO)
+	else if (device->getDeviceType() == OnixDeviceType::ANALOGIO)
 	{
 		auto analogIOFound = std::static_pointer_cast<AnalogIO>(device);
 		auto analogIOSelected = std::static_pointer_cast<AnalogIO>(settingsInterfaces[ind]->device);
@@ -201,7 +201,7 @@ void OnixSourceCanvas::updateSettingsInterfaceDataSource(std::shared_ptr<OnixDev
 			analogIOFound->setChannelDirection(i, analogIOSelected->getChannelDirection(i));
 		}
 	}
-	else if (device->type == OnixDeviceType::NEUROPIXELSV2E)
+	else if (device->getDeviceType() == OnixDeviceType::NEUROPIXELSV2E)
 	{
 		auto npx2Found = std::static_pointer_cast<Neuropixels2e>(device);
 		auto npx2Selected = std::static_pointer_cast<Neuropixels2e>(settingsInterfaces[ind]->device);
@@ -293,7 +293,7 @@ std::map<int, OnixDeviceType> OnixSourceCanvas::createSelectedMap(std::vector<st
 
 	for (const auto& settings : interfaces)
 	{
-		tabMap.insert({ settings->device->getDeviceIdx(), settings->device->type });
+		tabMap.insert({ settings->device->getDeviceIdx(), settings->device->getDeviceType() });
 	}
 
 	return tabMap;

--- a/Source/OnixSourceEditor.cpp
+++ b/Source/OnixSourceEditor.cpp
@@ -334,7 +334,7 @@ void OnixSourceEditor::startAcquisition()
 
 	for (const auto& source : source->getDataSources())
 	{
-		if (source->type == OnixDeviceType::MEMORYMONITOR)
+		if (source->getDeviceType() == OnixDeviceType::MEMORYMONITOR)
 		{
 			memoryUsage->setMemoryMonitor(std::static_pointer_cast<MemoryMonitor>(source));
 			memoryUsage->startAcquisition();
@@ -350,7 +350,7 @@ void OnixSourceEditor::stopAcquisition()
 
 	for (const auto& source : source->getDataSources())
 	{
-		if (source->type == OnixDeviceType::MEMORYMONITOR)
+		if (source->getDeviceType() == OnixDeviceType::MEMORYMONITOR)
 		{
 			memoryUsage->stopAcquisition();
 			break;

--- a/Source/UI/AnalogIOInterface.cpp
+++ b/Source/UI/AnalogIOInterface.cpp
@@ -55,7 +55,7 @@ AnalogIOInterface::AnalogIOInterface(std::shared_ptr<AnalogIO> d, OnixSourceEdit
 		voltageRangeList.add("+/- 5.0 V");
 		voltageRangeList.add("+/- 10.0 V");
 
-		for (int i = 0; i < numChannels; i += 1)
+		for (int i = 0; i < numChannels; i++)
 		{
 			channelDirectionLabels[i] = std::make_unique<Label>("channelDirectionLabel" + String(i), "Channel " + String(i) + String(": Direction"));
 			channelDirectionLabels[i]->setBounds(prevLabelRectangle.getX(), prevLabelRectangle.getBottom() + 4, prevLabelRectangle.getWidth(), prevLabelRectangle.getHeight());
@@ -103,7 +103,7 @@ void AnalogIOInterface::buttonClicked(Button* button)
 
 void AnalogIOInterface::comboBoxChanged(ComboBox* cb)
 {
-	for (int i = 0; i < numChannels; i += 1)
+	for (int i = 0; i < numChannels; i++)
 	{
 		if (cb == channelDirectionComboBoxes[i].get())
 		{


### PR DESCRIPTION
Fixes #57 

Additionally, fixes an undocumented error where the port voltage would remain high if the automated discovery failed. Now it resets the voltage to zero.