### PR TITLE
Add block read size functionality

### DIFF
--- a/Source/OnixSource.h
+++ b/Source/OnixSource.h
@@ -128,6 +128,10 @@ namespace OnixSourcePlugin
 			OwnedArray<DeviceInfo>* devices,
 			OwnedArray<ConfigurationObject>* configurationObjects);
 
+		uint32_t getBlockReadSize() const;
+
+		void setBlockReadSize(uint32_t);
+
 	private:
 
 		/** Available data sources */
@@ -148,7 +152,7 @@ namespace OnixSourcePlugin
 		std::shared_ptr<PortController> portA;
 		std::shared_ptr<PortController> portB;
 
-		const oni_size_t block_read_size = 2048;
+		uint32_t blockReadSize = 4096;
 
 		bool devicesFound = false;
 

--- a/Source/OnixSourceEditor.h
+++ b/Source/OnixSourceEditor.h
@@ -124,8 +124,11 @@ namespace OnixSourcePlugin
 
 		void setComboBoxSelection(ComboBox* comboBox, String headstage);
 		void addHeadstageComboBoxOptions(ComboBox* comboBox);
+		void enableEditorElements(bool);
 
 		std::unique_ptr<MemoryMonitorUsage> memoryUsage;
+
+		std::unique_ptr<Label> blockReadSizeValue;
 
 		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OnixSourceEditor);
 	};

--- a/Source/UI/NeuropixelsV1fInterface.cpp
+++ b/Source/UI/NeuropixelsV1fInterface.cpp
@@ -708,6 +708,8 @@ void NeuropixelsV1fInterface::buttonClicked(Button* button)
 			deviceEnableButton->setLabel(disabledButtonText);
 		}
 
+		updateInfoString();
+
 		CoreServices::updateSignalChain(editor);
 	}
 	else if (button == enableViewButton.get())

--- a/Source/UI/NeuropixelsV2eInterface.cpp
+++ b/Source/UI/NeuropixelsV2eInterface.cpp
@@ -103,6 +103,8 @@ void NeuropixelsV2eInterface::buttonClicked(Button* button)
 			deviceEnableButton->setLabel(disabledButtonText);
 		}
 
+		updateInfoString();
+
 		CoreServices::updateSignalChain(editor);
 	}
 }


### PR DESCRIPTION
This PR adds functionality to the block read size by adding a UI element in the editor to change it. Also cleans up some of the debug statements for read frame/write frame size, and shifts around some other UI elements to make space.

Default block read size has been changed from 2048 to 4096.

This PR also gives the added bonus of seeming to fix the memory buffer issue when streaming multiple Neuropixels probes. Previously, when it was set to 2048, the buffer would unpredictably but noticeably increase over time. Setting the block read size to 4096 appears to fix this behavior, or at the very least make it a much more rare occurrence. 

