### PR TITLE
Updated PolledBno055

### DIFF
--- a/Source/Devices/PolledBno055.cpp
+++ b/Source/Devices/PolledBno055.cpp
@@ -36,10 +36,10 @@ PolledBno055::PolledBno055(std::string name, std::string hubName, const oni_dev_
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Euler angle",
 		streamIdentifier,
 		3,
-		sampleRate,
+		SampleRate,
 		"Eul",
 		ContinuousChannel::Type::AUX,
-		eulerAngleScale,
+		EulerAngleScale,
 		"Degrees",
 		{ "Y", "R", "P" },
 		"euler",
@@ -52,10 +52,10 @@ PolledBno055::PolledBno055(std::string name, std::string hubName, const oni_dev_
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Quaternion",
 		streamIdentifier,
 		4,
-		sampleRate,
+		SampleRate,
 		"Quat",
 		ContinuousChannel::Type::AUX,
-		quaternionScale,
+		QuaternionScale,
 		"",
 		{ "W", "X", "Y", "Z" },
 		"quaternion",
@@ -68,10 +68,10 @@ PolledBno055::PolledBno055(std::string name, std::string hubName, const oni_dev_
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Acceleration",
 		streamIdentifier,
 		3,
-		sampleRate,
+		SampleRate,
 		"Acc",
 		ContinuousChannel::Type::AUX,
-		accelerationScale,
+		AccelerationScale,
 		"m / s ^ 2",
 		{ "X", "Y", "Z" },
 		"acceleration",
@@ -84,10 +84,10 @@ PolledBno055::PolledBno055(std::string name, std::string hubName, const oni_dev_
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Gravity",
 		streamIdentifier,
 		3,
-		sampleRate,
+		SampleRate,
 		"Grav",
 		ContinuousChannel::Type::AUX,
-		accelerationScale,
+		AccelerationScale,
 		"m/s^2",
 		{ "X", "Y", "Z" },
 		"gravity",
@@ -100,7 +100,7 @@ PolledBno055::PolledBno055(std::string name, std::string hubName, const oni_dev_
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Temperature",
 		streamIdentifier,
 		1,
-		sampleRate,
+		SampleRate,
 		"Temp",
 		ContinuousChannel::Type::AUX,
 		1.0f,
@@ -115,7 +115,7 @@ PolledBno055::PolledBno055(std::string name, std::string hubName, const oni_dev_
 		"Bosch Bno055 9-axis inertial measurement unit (IMU) Calibration status",
 		streamIdentifier,
 		4,
-		sampleRate,
+		SampleRate,
 		"Cal",
 		ContinuousChannel::Type::AUX,
 		1.0f,
@@ -126,8 +126,13 @@ PolledBno055::PolledBno055(std::string name, std::string hubName, const oni_dev_
 	);
 	streamInfos.add(calibrationStatusStream);
 
-	for (int i = 0; i < numFrames; i++)
+	for (int i = 0; i < NumFrames; i++)
 		eventCodes[i] = 0;
+}
+
+PolledBno055::~PolledBno055()
+{
+	stopTimer();
 }
 
 OnixDeviceType PolledBno055::getDeviceType()
@@ -174,7 +179,7 @@ bool PolledBno055::updateSettings()
 	rc = WriteByte(0x3D, 0x0C); // Operation mode is NDOF
 	if (rc != ONI_ESUCCESS) return false;
 
-	rc = set933I2cRate(i2cRate);
+	rc = set933I2cRate(I2cRate);
 
 	return rc == ONI_ESUCCESS;
 }
@@ -203,7 +208,7 @@ void PolledBno055::addFrame(oni_frame_t* frame)
 
 void PolledBno055::addSourceBuffers(OwnedArray<DataBuffer>& sourceBuffers)
 {
-	sourceBuffers.add(new DataBuffer(numberOfChannels, (int)sampleRate * bufferSizeInSeconds));
+	sourceBuffers.add(new DataBuffer(NumberOfChannels, (int)SampleRate * bufferSizeInSeconds));
 	bnoBuffer = sourceBuffers.getLast();
 }
 
@@ -223,43 +228,43 @@ void PolledBno055::hiResTimerCallback()
 	size_t offset = 0;
 
 	// Euler
-	bnoSamples[offset++ * numFrames + currentFrame] = readInt16(EulerHeadingLsbAddress) * eulerAngleScale;
-	bnoSamples[offset++ * numFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 2) * eulerAngleScale;
-	bnoSamples[offset++ * numFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 4) * eulerAngleScale;
+	bnoSamples[offset++ * NumFrames + currentFrame] = readInt16(EulerHeadingLsbAddress) * EulerAngleScale;
+	bnoSamples[offset++ * NumFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 2) * EulerAngleScale;
+	bnoSamples[offset++ * NumFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 4) * EulerAngleScale;
 
 	// Quaternion
-	bnoSamples[offset++ * numFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 6) * quaternionScale;
-	bnoSamples[offset++ * numFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 8) * quaternionScale;
-	bnoSamples[offset++ * numFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 10) * quaternionScale;
-	bnoSamples[offset++ * numFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 12) * quaternionScale;
+	bnoSamples[offset++ * NumFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 6) * QuaternionScale;
+	bnoSamples[offset++ * NumFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 8) * QuaternionScale;
+	bnoSamples[offset++ * NumFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 10) * QuaternionScale;
+	bnoSamples[offset++ * NumFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 12) * QuaternionScale;
 
 	// Acceleration
 
-	bnoSamples[offset++ * numFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 14) * accelerationScale;
-	bnoSamples[offset++ * numFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 16) * accelerationScale;
-	bnoSamples[offset++ * numFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 18) * accelerationScale;
+	bnoSamples[offset++ * NumFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 14) * AccelerationScale;
+	bnoSamples[offset++ * NumFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 16) * AccelerationScale;
+	bnoSamples[offset++ * NumFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 18) * AccelerationScale;
 
 	// Gravity
 
-	bnoSamples[offset++ * numFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 20) * accelerationScale;
-	bnoSamples[offset++ * numFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 22) * accelerationScale;
-	bnoSamples[offset++ * numFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 24) * accelerationScale;
+	bnoSamples[offset++ * NumFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 20) * AccelerationScale;
+	bnoSamples[offset++ * NumFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 22) * AccelerationScale;
+	bnoSamples[offset++ * NumFrames + currentFrame] = readInt16(EulerHeadingLsbAddress + 24) * AccelerationScale;
 
 	// Temperature
 
 	oni_reg_val_t byte;
 	ReadByte(EulerHeadingLsbAddress + 26, &byte);
-	bnoSamples[offset++ * numFrames + currentFrame] = static_cast<uint8_t>(byte);
+	bnoSamples[offset++ * NumFrames + currentFrame] = static_cast<uint8_t>(byte);
 
 	// Calibration Status
 
 	ReadByte(EulerHeadingLsbAddress + 27, &byte);
-	
+
 	constexpr uint8_t statusMask = 0b11;
 
 	for (int i = 0; i < 4; i++)
 	{
-		bnoSamples[currentFrame + (offset + i) * numFrames] = (byte & (statusMask << (2 * i))) >> (2 * i);
+		bnoSamples[currentFrame + (offset + i) * NumFrames] = (byte & (statusMask << (2 * i))) >> (2 * i);
 	}
 
 	oni_reg_val_t timestampL = 0, timestampH = 0;
@@ -274,9 +279,9 @@ void PolledBno055::hiResTimerCallback()
 
 	currentFrame++;
 
-	if (currentFrame >= numFrames)
+	if (currentFrame >= NumFrames)
 	{
-		bnoBuffer->addToBuffer(bnoSamples.data(), sampleNumbers, bnoTimestamps, eventCodes, numFrames);
+		bnoBuffer->addToBuffer(bnoSamples.data(), sampleNumbers, bnoTimestamps, eventCodes, NumFrames);
 		currentFrame = 0;
 	}
 }

--- a/Source/Devices/PolledBno055.h
+++ b/Source/Devices/PolledBno055.h
@@ -40,26 +40,14 @@ namespace OnixSourcePlugin
 		/** Constructor */
 		PolledBno055(std::string name, std::string hubName, const oni_dev_idx_t, std::shared_ptr<Onix1> ctx);
 
-		~PolledBno055()
-		{
-			stopTimer();
-		}
+		~PolledBno055();
 
 		int configureDevice() override;
-
-		/** Update the settings of the device */
 		bool updateSettings() override;
-
-		/** Starts probe data streaming */
 		void startAcquisition() override;
-
-		/** Stops probe data streaming*/
 		void stopAcquisition() override;
-
 		void addFrame(oni_frame_t*) override;
-
-		void processFrames() override {};
-
+		void processFrames() override;
 		void addSourceBuffers(OwnedArray<DataBuffer>& sourceBuffers) override;
 
 		void hiResTimerCallback() override;
@@ -91,50 +79,38 @@ namespace OnixSourcePlugin
 
 		DataBuffer* bnoBuffer;
 
-		static const int Bno055Address = 0x28;
-		static const int EulerHeadingLsbAddress = 0x1A;
+		static constexpr int Bno055Address = 0x28;
+		static constexpr int EulerHeadingLsbAddress = 0x1A;
 
-		const double i2cRate = 400e3;
+		static constexpr double I2cRate = 400e3;
 
-		static const int numberOfBytes = 28;
+		static constexpr int NumberOfBytes = 28;
 
-		const float eulerAngleScale = 1.0f / 16; // 1 degree = 16 LSB
-		const float quaternionScale = 1.0f / (1 << 14); // 1 = 2^14 LSB
-		const float accelerationScale = 1.0f / 100; // 1m / s^2 = 100 LSB
+		static constexpr float EulerAngleScale = 1.0f / 16; // 1 degree = 16 LSB
+		static constexpr float QuaternionScale = 1.0f / (1 << 14); // 1 = 2^14 LSB
+		static constexpr float AccelerationScale = 1.0f / 100; // 1m / s^2 = 100 LSB
 
 		std::unique_ptr<I2CRegisterContext> deserializer;
-
-		enum class PolledBno055Registers : int32_t
-		{
-			EulerAngle = 0x1, // Specifies that the Euler angles will be polled.
-			Quaternion = 0x2, // Specifies that the quaternion will be polled.
-			Acceleration = 0x4, // Specifies that the linear acceleration will be polled.
-			Gravity = 0x8, // Specifies that the gravity vector will be polled.
-			Temperature = 0x10, // Specifies that the temperature measurement will be polled.
-			Calibration = 0x20, // Specifies that the sensor calibration status will be polled.
-			All = EulerAngle | Quaternion | Acceleration | Gravity | Temperature | Calibration, // Specifies that all sensor measurements and calibration status will be polled.
-		};
 
 		Bno055AxisMap axisMap = Bno055AxisMap::XYZ;
 		uint32_t axisSign = (uint32_t)Bno055AxisSign::Default; // NB: Holds the uint value of the flag. Allows for combinations of X/Y/Z to combined together
 
-		static const int numberOfChannels = 3 + 3 + 4 + 3 + 1 + 4;
-		static constexpr double sampleRate = 30.0;
+		static constexpr int NumberOfChannels = 3 + 3 + 4 + 3 + 1 + 4;
+		static constexpr double SampleRate = 30.0;
 
-		static const int timerIntervalInMilliseconds = (int)(1e3 * (1 / sampleRate));
+		static constexpr int TimerIntervalInMilliseconds = (int)(1e3 * (1 / SampleRate));
 
-		static const int numFrames = 2;
+		static constexpr int NumFrames = 2;
 
-		std::array<float, numberOfChannels* numFrames> bnoSamples;
+		std::array<float, NumberOfChannels * NumFrames> bnoSamples;
 
-		double bnoTimestamps[numFrames];
-		int64 sampleNumbers[numFrames];
-		uint64 eventCodes[numFrames];
+		double bnoTimestamps[NumFrames];
+		int64 sampleNumbers[NumFrames];
+		uint64 eventCodes[NumFrames];
 
 		unsigned short currentFrame = 0;
 		int sampleNumber = 0;
 
-		// Given the starting address (i.e., the LSB), read two bytes and convert to an int16_t
 		int16_t readInt16(uint32_t);
 
 		JUCE_LEAK_DETECTOR(PolledBno055);

--- a/Source/Onix1.cpp
+++ b/Source/Onix1.cpp
@@ -121,21 +121,24 @@ std::vector<int> Onix1::getDeviceIndices(device_map_t deviceMap, int hubIndex)
 int Onix1::get_opt_(int option, void* value, size_t* size) const
 {
 	int rc = oni_get_opt(ctx_, option, value, size);
-	if (rc != ONI_ESUCCESS) LOGE(oni_error_str(rc));
+	if (rc != ONI_ESUCCESS)
+		LOGE(oni_error_str(rc));
 	return rc;
 }
 
 int Onix1::readRegister(oni_dev_idx_t devIndex, oni_reg_addr_t registerAddress, oni_reg_val_t* value) const
 {
 	int rc = oni_read_reg(ctx_, devIndex, registerAddress, value);
-	if (rc != ONI_ESUCCESS) LOGE(oni_error_str(rc));
+	if (rc != ONI_ESUCCESS)
+		LOGE(oni_error_str(rc));
 	return rc;
 }
 
 int Onix1::writeRegister(oni_dev_idx_t devIndex, oni_reg_addr_t registerAddress, oni_reg_val_t value) const
 {
 	int rc = oni_write_reg(ctx_, devIndex, registerAddress, value);
-	if (rc != ONI_ESUCCESS) LOGE(oni_error_str(rc));
+	if (rc != ONI_ESUCCESS)
+		LOGE(oni_error_str(rc));
 	return rc;
 }
 
@@ -171,7 +174,7 @@ oni_frame_t* Onix1::readFrame() const
 
 void Onix1::showWarningMessageBoxAsync(std::string title, std::string error_msg)
 {
-	LOGE(error_msg);
+	LOGD(error_msg);
 	MessageManager::callAsync([title, error_msg]
 		{
 			AlertWindow::showMessageBoxAsync(

--- a/Source/Onix1.cpp
+++ b/Source/Onix1.cpp
@@ -139,6 +139,23 @@ int Onix1::writeRegister(oni_dev_idx_t devIndex, oni_reg_addr_t registerAddress,
 	return rc;
 }
 
+int Onix1::issueReset() 
+{ 
+	int val = 1; 
+	int rc = setOption(ONI_OPT_RESET, val); 
+	return rc;
+}
+
+std::string Onix1::getVersion() const 
+{ 
+	return std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch);
+}
+
+double Onix1::convertTimestampToSeconds(uint64_t timestamp) const
+{ 
+	return static_cast<double>(timestamp) / ACQ_CLK_HZ;
+}
+
 oni_frame_t* Onix1::readFrame() const
 {
 	oni_frame_t* frame = nullptr;

--- a/Source/Onix1.cpp
+++ b/Source/Onix1.cpp
@@ -120,6 +120,8 @@ std::vector<int> Onix1::getDeviceIndices(device_map_t deviceMap, int hubIndex)
 
 int Onix1::get_opt_(int option, void* value, size_t* size) const
 {
+	const ScopedLock lock(optionLock);
+
 	int rc = oni_get_opt(ctx_, option, value, size);
 	if (rc != ONI_ESUCCESS)
 		LOGE(oni_error_str(rc));
@@ -128,6 +130,8 @@ int Onix1::get_opt_(int option, void* value, size_t* size) const
 
 int Onix1::readRegister(oni_dev_idx_t devIndex, oni_reg_addr_t registerAddress, oni_reg_val_t* value) const
 {
+	const ScopedLock lock(registerLock);
+
 	int rc = oni_read_reg(ctx_, devIndex, registerAddress, value);
 	if (rc != ONI_ESUCCESS)
 		LOGE(oni_error_str(rc));
@@ -136,6 +140,8 @@ int Onix1::readRegister(oni_dev_idx_t devIndex, oni_reg_addr_t registerAddress, 
 
 int Onix1::writeRegister(oni_dev_idx_t devIndex, oni_reg_addr_t registerAddress, oni_reg_val_t value) const
 {
+	const ScopedLock lock(registerLock);
+
 	int rc = oni_write_reg(ctx_, devIndex, registerAddress, value);
 	if (rc != ONI_ESUCCESS)
 		LOGE(oni_error_str(rc));
@@ -161,6 +167,8 @@ double Onix1::convertTimestampToSeconds(uint64_t timestamp) const
 
 oni_frame_t* Onix1::readFrame() const
 {
+	const ScopedLock lock(frameLock);
+
 	oni_frame_t* frame = nullptr;
 	int rc = oni_read_frame(ctx_, &frame);
 	if (rc < ONI_ESUCCESS)

--- a/Source/Onix1.h
+++ b/Source/Onix1.h
@@ -27,6 +27,8 @@
 #include <system_error>
 #include <exception>
 
+#include <DataThreadHeaders.h>
+
 #include "../../plugin-GUI/Source/Utils/Utils.h"
 
 namespace OnixSourcePlugin
@@ -90,6 +92,8 @@ namespace OnixSourcePlugin
 		template <typename opt_t>
 		int setOption(int option, const opt_t value)
 		{
+			const ScopedLock lock(optionLock);
+
 			int rc = oni_set_opt(ctx_, option, &value, opt_size_<opt_t>(value));
 			if (rc != ONI_ESUCCESS) LOGE(oni_error_str(rc));
 			return rc;
@@ -122,6 +126,10 @@ namespace OnixSourcePlugin
 
 		/** The ONI ctx object */
 		oni_ctx ctx_;
+
+		CriticalSection registerLock;
+		CriticalSection frameLock;
+		CriticalSection optionLock;
 
 		int major;
 		int minor;

--- a/Source/Onix1.h
+++ b/Source/Onix1.h
@@ -103,11 +103,11 @@ namespace OnixSourcePlugin
 
 		oni_frame_t* readFrame() const;
 
-		int issueReset() { int val = 1; int rc = setOption(ONI_OPT_RESET, val); return rc; }
+		int issueReset();
 
-		std::string getVersion() const { return std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch); }
+		std::string getVersion() const;
 
-		double convertTimestampToSeconds(uint32_t timestamp) const { return static_cast<double>(timestamp) / ACQ_CLK_HZ; }
+		double convertTimestampToSeconds(uint64_t timestamp) const;
 
 		/** Gets a map of all hubs connected, where the index of the map is the hub address, and the value is the hub ID */
 		std::map<int, int> getHubIds(device_map_t) const;

--- a/Source/OnixDevice.h
+++ b/Source/OnixDevice.h
@@ -22,8 +22,6 @@
 
 #pragma once
 
-#include <DataThreadHeaders.h>
-
 #include <ctime>
 #include <ratio>
 #include <chrono>

--- a/Source/OnixSource.cpp
+++ b/Source/OnixSource.cpp
@@ -64,6 +64,23 @@ OnixSource::OnixSource(SourceNode* sn) :
 	if (!context->isInitialized()) { LOGE("Failed to initialize context."); return; }
 }
 
+OnixSource::~OnixSource()
+{
+	if (context != nullptr && context->isInitialized())
+	{
+		portA->setVoltageOverride(0.0f, false);
+		portB->setVoltageOverride(0.0f, false);
+	}
+}
+
+std::string OnixSource::getLiboniVersion()
+{
+	if (context != nullptr && context->isInitialized())
+		return context->getVersion();
+	else
+		return "";
+}
+
 void OnixSource::registerParameters()
 {
 	addBooleanParameter(Parameter::PROCESSOR_SCOPE, "passthroughA", "Passthrough A", "Enables passthrough mode for e-variant headstages on Port A", false, true);

--- a/Source/OnixSource.cpp
+++ b/Source/OnixSource.cpp
@@ -1052,12 +1052,6 @@ bool OnixSource::stopAcquisition()
 	if (!portA->getErrorFlag() && !portB->getErrorFlag())
 		waitForThreadToExit(2000);
 
-	for (const auto& polledBno055 : getDevices(OnixDeviceType::POLLEDBNO))
-	{
-		if (polledBno055 != nullptr && polledBno055->isEnabled())
-			polledBno055->stopAcquisition(); // NB: Polled BNO must be stopped before other devices to ensure there are no stream clashes
-	}
-
 	for (const auto& source : enabledSources)
 	{
 		source->stopAcquisition();

--- a/Source/OnixSource.cpp
+++ b/Source/OnixSource.cpp
@@ -799,7 +799,8 @@ void OnixSource::updateSettings(OwnedArray<ContinuousChannel>* continuousChannel
 					OnixDevice::createStreamName({OnixDevice::getPortNameFromIndex(source->getDeviceIdx()), source->getHubName(), source->getName()}),
 					"Continuous data from a Bno055 9-axis IMU",
 					source->getStreamIdentifier(),
-					source->streamInfos[0].getSampleRate()
+					source->streamInfos[0].getSampleRate(),
+					true
 				};
 
 				addCombinedStreams(dataStreamSettings, source->streamInfos, dataStreams, deviceInfos, continuousChannels);
@@ -934,7 +935,8 @@ void OnixSource::addIndividualStreams(Array<StreamInfo> streamInfos,
 			streamInfo.getName(),
 			streamInfo.getDescription(),
 			streamInfo.getStreamIdentifier(),
-			streamInfo.getSampleRate()
+			streamInfo.getSampleRate(),
+			true
 		};
 
 		DataStream* stream = new DataStream(streamSettings);
@@ -1050,9 +1052,7 @@ bool OnixSource::stopAcquisition()
 	if (!portA->getErrorFlag() && !portB->getErrorFlag())
 		waitForThreadToExit(2000);
 
-	auto polledBno055s = getDevices(OnixDeviceType::POLLEDBNO);
-
-	for (const auto& polledBno055 : polledBno055s)
+	for (const auto& polledBno055 : getDevices(OnixDeviceType::POLLEDBNO))
 	{
 		if (polledBno055 != nullptr && polledBno055->isEnabled())
 			polledBno055->stopAcquisition(); // NB: Polled BNO must be stopped before other devices to ensure there are no stream clashes

--- a/Source/OnixSource.h
+++ b/Source/OnixSource.h
@@ -45,14 +45,7 @@ namespace OnixSourcePlugin
 		OnixSource(SourceNode* sn);
 
 		/** Destructor */
-		~OnixSource()
-		{
-			if (context != nullptr && context->isInitialized())
-			{
-				portA->setVoltageOverride(0.0f, false);
-				portB->setVoltageOverride(0.0f, false);
-			}
-		}
+		~OnixSource();
 
 		void registerParameters() override;
 
@@ -123,7 +116,7 @@ namespace OnixSourcePlugin
 
 		std::map<int, std::string> getHubNames();
 
-		std::string getLiboniVersion() { if (context != nullptr && context->isInitialized()) return context->getVersion(); else return ""; }
+		std::string getLiboniVersion();
 
 		void updateSourceBuffers();
 


### PR DESCRIPTION
This update refactors the `PolledBno055` device so that it no longer uses the `HighResolutionTimer` Juce class. Now, it runs on a regular `Thread` class and utilizes `std::chrono::steady_clock` to count intervals to ensure that the timer is not shared across multiple sources.

This PR also takes greater advantage of the new multi-byte read functionality to minimize the number of register reads while polling. Instead of reading two bytes at a time to get the full word for each value, now it reads four bytes at a time and then separates the higher and lower bits to create the individual values.

Testing shows that setting the sample rate at 100 Hz was able to achieve this rate, on average. There is some jitter in the acquisition, but the mean value is very close to 10 ms between successive timestamps.