### PR TITLE
Add save and load settings functionality to various interfaces

### DIFF
--- a/Source/UI/AnalogIOInterface.cpp
+++ b/Source/UI/AnalogIOInterface.cpp
@@ -72,6 +72,20 @@ AnalogIOInterface::AnalogIOInterface(std::shared_ptr<AnalogIO> d, OnixSourceEdit
 			prevComboBoxRectangle = channelDirectionComboBoxes[i]->getBounds();
 		}
 
+		saveSettingsButton = std::make_unique<UtilityButton>("Save Settings");
+		saveSettingsButton->setRadius(3.0f);
+		saveSettingsButton->setBounds(deviceEnableButton->getX() + 3, channelDirectionLabels[numChannels - 1]->getBottom() + 20, 120, 22);
+		saveSettingsButton->addListener(this);
+		saveSettingsButton->setTooltip("Save all AnalogIO settings to file.");
+		addAndMakeVisible(saveSettingsButton.get());
+
+		loadSettingsButton = std::make_unique<UtilityButton>("Load Settings");
+		loadSettingsButton->setRadius(3.0f);
+		loadSettingsButton->setBounds(saveSettingsButton->getRight() + 5, saveSettingsButton->getY(), saveSettingsButton->getWidth(), saveSettingsButton->getHeight());
+		loadSettingsButton->addListener(this);
+		loadSettingsButton->setTooltip("Load all AnalogIO settings from a file.");
+		addAndMakeVisible(loadSettingsButton.get());
+
 		updateInfoString();
 
 		updateSettings();
@@ -138,6 +152,32 @@ void AnalogIOInterface::buttonClicked(Button* button)
 		}
 
 		CoreServices::updateSignalChain(editor);
+	}
+	else if (button == saveSettingsButton.get())
+	{
+		FileChooser fileChooser("Save AnalogIO settings to an XML file.", File(), "*.xml");
+
+		if (fileChooser.browseForFileToSave(true))
+		{
+			XmlElement rootElement("DEVICE");
+
+			saveParameters(&rootElement);
+
+			writeToXmlFile(&rootElement, fileChooser.getResult());
+		}
+	}
+	else if (button == loadSettingsButton.get())
+	{
+		FileChooser fileChooser("Load AnalogIO settings from an XML file.", File(), "*.xml");
+
+		if (fileChooser.browseForFileToOpen())
+		{
+			auto rootElement = readFromXmlFile(fileChooser.getResult());
+
+			loadParameters(rootElement);
+
+			delete rootElement;
+		}
 	}
 }
 

--- a/Source/UI/AnalogIOInterface.h
+++ b/Source/UI/AnalogIOInterface.h
@@ -60,6 +60,9 @@ namespace OnixSourcePlugin
 
 		std::unique_ptr<UtilityButton> deviceEnableButton;
 
+		std::unique_ptr<UtilityButton> saveSettingsButton;
+		std::unique_ptr<UtilityButton> loadSettingsButton;
+
 		static int getChannelDirectionId(std::shared_ptr<AnalogIO> device, int channelNumber);
 		static int getChannelVoltageRangeId(std::shared_ptr<AnalogIO> device, int channelNumber);
 		static int getDataTypeId(std::shared_ptr<AnalogIO> device);

--- a/Source/UI/NeuropixelsV1Interface.h
+++ b/Source/UI/NeuropixelsV1Interface.h
@@ -75,8 +75,6 @@ namespace OnixSourcePlugin
 
 		void setInterfaceEnabledState(bool newState) override;
 
-		XmlElement neuropix_info;
-
 		bool acquisitionIsActive = false;
 
 		std::unique_ptr<ComboBox> electrodeConfigurationComboBox;
@@ -141,6 +139,9 @@ namespace OnixSourcePlugin
 		std::vector<std::unique_ptr<DrawableRectangle>> lfpGainViewRectangles;
 		std::vector<std::unique_ptr<DrawableRectangle>> referenceViewRectangles;
 		std::vector<std::unique_ptr<DrawableRectangle>> activityViewRectangles;
+
+		std::unique_ptr<UtilityButton> saveSettingsButton;
+		std::unique_ptr<UtilityButton> loadSettingsButton;
 
 		void drawLegend();
 

--- a/Source/UI/NeuropixelsV2eProbeInterface.cpp
+++ b/Source/UI/NeuropixelsV2eProbeInterface.cpp
@@ -32,7 +32,6 @@ using namespace ColourScheme;
 
 NeuropixelsV2eProbeInterface::NeuropixelsV2eProbeInterface(std::shared_ptr<Neuropixels2e> d, int ind, OnixSourceEditor* e, OnixSourceCanvas* c) :
 	SettingsInterface(d, e, c),
-	neuropix_info("INFO"),
 	probeIndex(ind)
 {
 	ColourScheme::setColourScheme(ColourSchemeId::PLASMA);
@@ -111,6 +110,20 @@ NeuropixelsV2eProbeInterface::NeuropixelsV2eProbeInterface(std::shared_ptr<Neuro
 		loadJsonButton->addListener(this);
 		loadJsonButton->setTooltip("Load channel map from probeinterface .json file");
 		addAndMakeVisible(loadJsonButton.get());
+
+		saveSettingsButton = std::make_unique<UtilityButton>("Save Settings");
+		saveSettingsButton->setRadius(3.0f);
+		saveSettingsButton->setBounds(saveJsonButton->getX(), saveJsonButton->getBottom() + 20, 120, 22);
+		saveSettingsButton->addListener(this);
+		saveSettingsButton->setTooltip("Save all Neuropixels settings to file.");
+		addAndMakeVisible(saveSettingsButton.get());
+
+		loadSettingsButton = std::make_unique<UtilityButton>("Load Settings");
+		loadSettingsButton->setRadius(3.0f);
+		loadSettingsButton->setBounds(saveSettingsButton->getRight() + 5, saveSettingsButton->getY(), saveSettingsButton->getWidth(), saveSettingsButton->getHeight());
+		loadSettingsButton->addListener(this);
+		loadSettingsButton->setTooltip("Load all Neuropixels settings from a file.");
+		addAndMakeVisible(loadSettingsButton.get());
 
 		electrodesLabel = std::make_unique<Label>("ELECTRODES", "ELECTRODES");
 		electrodesLabel->setFont(FontOptions("Inter", "Regular", 13.0f));
@@ -440,6 +453,32 @@ void NeuropixelsV2eProbeInterface::buttonClicked(Button* button)
 				CoreServices::sendStatusMessage("Failed to write probe channel map.");
 			else
 				CoreServices::sendStatusMessage("Successfully wrote probe channel map.");
+		}
+	}
+	else if (button == saveSettingsButton.get())
+	{
+		FileChooser fileChooser("Save Neuropixels settings to an XML file.", File(), "*.xml");
+
+		if (fileChooser.browseForFileToSave(true))
+		{
+			XmlElement rootElement("DEVICE");
+
+			saveParameters(&rootElement);
+
+			writeToXmlFile(&rootElement, fileChooser.getResult());
+		}
+	}
+	else if (button == loadSettingsButton.get())
+	{
+		FileChooser fileChooser("Load Neuropixels settings from an XML file.", File(), "*.xml");
+
+		if (fileChooser.browseForFileToOpen())
+		{
+			auto rootElement = readFromXmlFile(fileChooser.getResult());
+
+			loadParameters(rootElement);
+
+			delete rootElement;
 		}
 	}
 	else if (button == gainCorrectionFileButton.get())

--- a/Source/UI/NeuropixelsV2eProbeInterface.h
+++ b/Source/UI/NeuropixelsV2eProbeInterface.h
@@ -73,8 +73,6 @@ namespace OnixSourcePlugin
 		std::string getReferenceText() override { return referenceComboBox->getText().toStdString(); }
 
 	private:
-		XmlElement neuropix_info;
-
 		bool acquisitionIsActive = false;
 
 		const int probeIndex;
@@ -116,6 +114,9 @@ namespace OnixSourcePlugin
 		std::vector<std::unique_ptr<DrawableRectangle>> enableViewRectangles;
 		std::vector<std::unique_ptr<DrawableRectangle>> referenceViewRectangles;
 		std::vector<std::unique_ptr<DrawableRectangle>> activityViewRectangles;
+
+		std::unique_ptr<UtilityButton> saveSettingsButton;
+		std::unique_ptr<UtilityButton> loadSettingsButton;
 
 		void drawLegend();
 

--- a/Source/UI/OutputClockInterface.cpp
+++ b/Source/UI/OutputClockInterface.cpp
@@ -79,6 +79,20 @@ OutputClockInterface::OutputClockInterface(std::shared_ptr<OutputClock> d, OnixS
 		gateRunButton->addListener(this);
 		addAndMakeVisible(gateRunButton.get());
 
+		saveSettingsButton = std::make_unique<UtilityButton>("Save Settings");
+		saveSettingsButton->setRadius(3.0f);
+		saveSettingsButton->setBounds(gateRunButton->getX() + 3, gateRunButton->getBottom() + 20, 120, 22);
+		saveSettingsButton->addListener(this);
+		saveSettingsButton->setTooltip("Save all OutputClock settings to file.");
+		addAndMakeVisible(saveSettingsButton.get());
+
+		loadSettingsButton = std::make_unique<UtilityButton>("Load Settings");
+		loadSettingsButton->setRadius(3.0f);
+		loadSettingsButton->setBounds(saveSettingsButton->getRight() + 5, saveSettingsButton->getY(), saveSettingsButton->getWidth(), saveSettingsButton->getHeight());
+		loadSettingsButton->addListener(this);
+		loadSettingsButton->setTooltip("Load all OutputClock settings from a file.");
+		addAndMakeVisible(loadSettingsButton.get());
+
 		updateSettings();
 	}
 
@@ -119,6 +133,32 @@ void OutputClockInterface::buttonClicked(Button* b)
 	if (b == gateRunButton.get())
 	{
 		outputClock->setGateRun(gateRunButton->getToggleState(), editor->acquisitionIsActive);
+	}
+	else if (b == saveSettingsButton.get())
+	{
+		FileChooser fileChooser("Save OutputClock settings to an XML file.", File(), "*.xml");
+
+		if (fileChooser.browseForFileToSave(true))
+		{
+			XmlElement rootElement("DEVICE");
+
+			saveParameters(&rootElement);
+
+			writeToXmlFile(&rootElement, fileChooser.getResult());
+		}
+	}
+	else if (b == loadSettingsButton.get())
+	{
+		FileChooser fileChooser("Load OutputClock settings from an XML file.", File(), "*.xml");
+
+		if (fileChooser.browseForFileToOpen())
+		{
+			auto rootElement = readFromXmlFile(fileChooser.getResult());
+
+			loadParameters(rootElement);
+
+			delete rootElement;
+		}
 	}
 }
 

--- a/Source/UI/OutputClockInterface.h
+++ b/Source/UI/OutputClockInterface.h
@@ -65,6 +65,9 @@ namespace OnixSourcePlugin
 
 		std::unique_ptr<ToggleButton> gateRunButton;
 
+		std::unique_ptr<UtilityButton> saveSettingsButton;
+		std::unique_ptr<UtilityButton> loadSettingsButton;
+
 		const float MinFrequencyHz = 0.1f;
 		const float MaxFrequencyHz = 10e6;
 

--- a/Source/UI/SettingsInterface.h
+++ b/Source/UI/SettingsInterface.h
@@ -110,6 +110,33 @@ namespace OnixSourcePlugin
 		const std::string enabledButtonText = "DISABLE";
 		const std::string disabledButtonText = "ENABLE";
 
+		static void writeToXmlFile(XmlElement* rootElement, File file)
+		{
+			if (!rootElement->writeToFile(file, String()))
+			{
+				Onix1::showWarningMessageBoxAsync(
+					"Failed to Write XML File",
+					"Unable to write the file " + file.getFullPathName().toStdString());
+			}
+		}
+
+		static XmlElement* readFromXmlFile(File file)
+		{
+			XmlDocument xmlDocument(file);
+
+			auto rootElement = xmlDocument.getDocumentElement();
+
+			if (rootElement == nullptr)
+			{
+				Onix1::showWarningMessageBoxAsync(
+					"Failed to Read XML File",
+					"Unable to read the file " + file.getFullPathName().toStdString());
+				return nullptr;
+			}
+
+			return rootElement.release();
+		}
+
 	private:
 
 		/** Enables or disables all UI elements that should not be changed during acquisition */


### PR DESCRIPTION
This PR adds two buttons to most of the device settings tabs: `Save Settings` and `Load Settings`. These buttons utilize the pre-existing `saveParameters` and `loadParameters` methods in the settings classes to write/read the settings in an XML format. 

- Fixes #6 