### PR TITLE
Color selected electrodes as dark grey if the device is disabled

### DIFF
--- a/Source/UI/NeuropixelsV1Interface.cpp
+++ b/Source/UI/NeuropixelsV1Interface.cpp
@@ -703,6 +703,7 @@ void NeuropixelsV1Interface::buttonClicked(Button* button)
 		}
 
 		updateInfoString();
+		repaint();
 
 		CoreServices::updateSignalChain(editor);
 	}

--- a/Source/UI/NeuropixelsV2eInterface.cpp
+++ b/Source/UI/NeuropixelsV2eInterface.cpp
@@ -104,6 +104,7 @@ void NeuropixelsV2eInterface::buttonClicked(Button* button)
 		}
 
 		updateInfoString();
+		repaint();
 
 		CoreServices::updateSignalChain(editor);
 	}

--- a/Source/UI/ProbeBrowser.h
+++ b/Source/UI/ProbeBrowser.h
@@ -622,8 +622,9 @@ namespace OnixSourcePlugin
 		Colour getElectrodeColour(int i)
 		{
 			auto mode = parent->getMode();
-
 			auto settings = getSettings();
+			auto device = parent->getDevice();
+			
 			if (settings == nullptr) return Colours::grey;
 
 			if (settings->electrodeMetadata[i].status == ElectrodeStatus::DISCONNECTED) // not available
@@ -631,7 +632,13 @@ namespace OnixSourcePlugin
 				return disconnectedColors[settings->electrodeMetadata[i].bank];
 			}
 			else if (settings->electrodeMetadata[i].type == ElectrodeType::REFERENCE)
+			{
 				return Colours::black;
+			}
+			else if (!device->isEnabled())
+			{
+				return Colours::darkgrey;
+			}
 			else
 			{
 				if (mode == VisualizationMode::ENABLE_VIEW) // ENABLED STATE


### PR DESCRIPTION
All electrodes that are selected will be colored dark grey if the device is disabled. This effect takes place immediately after pressing the enable/disable button.

- Fixes #67 