### PR TITLE
Update Probe Viewer

### DIFF
--- a/Source/NeuropixelsComponents.h
+++ b/Source/NeuropixelsComponents.h
@@ -65,6 +65,23 @@ namespace OnixSourcePlugin
 		K = 10,
 		L = 11,
 		M = 12,
+		A1 = 13, // used for quad base
+		A2 = 14,
+		A3 = 15,
+		A4 = 16,
+		B1 = 17,
+		B2 = 18,
+		B3 = 19,
+		B4 = 20,
+		C1 = 21,
+		C2 = 22,
+		C3 = 23,
+		C4 = 24,
+		D1 = 25,
+		D2 = 26,
+		D3 = 27,
+		D4 = 28,
+		OFF = 255 //used in v1 API
 	};
 
 	enum class ElectrodeStatus

--- a/Source/UI/ProbeBrowser.h
+++ b/Source/UI/ProbeBrowser.h
@@ -37,6 +37,7 @@ namespace OnixSourcePlugin
 		{
 			parent = parent_;
 			probeIndex = probeIndex_;
+			tooltipWindow = std::make_unique <TooltipWindow>(parent, 300);
 
 			cursorType = MouseCursor::NormalCursor;
 
@@ -118,10 +119,27 @@ namespace OnixSourcePlugin
 			lowerBound = 530; // bottom of interface
 
 			disconnectedColors[Bank::NONE] = Colour(0, 0, 0);
+			disconnectedColors[Bank::OFF] = Colour(0, 0, 0);
 			disconnectedColors[Bank::A] = Colour(180, 180, 180);
+			disconnectedColors[Bank::A1] = Colour(180, 180, 180);
+			disconnectedColors[Bank::A1] = Colour(180, 180, 180);
+			disconnectedColors[Bank::A1] = Colour(180, 180, 180);
+			disconnectedColors[Bank::A1] = Colour(180, 180, 180);
 			disconnectedColors[Bank::B] = Colour(160, 160, 160);
+			disconnectedColors[Bank::B1] = Colour(160, 160, 160);
+			disconnectedColors[Bank::B2] = Colour(160, 160, 160);
+			disconnectedColors[Bank::B3] = Colour(160, 160, 160);
+			disconnectedColors[Bank::B4] = Colour(160, 160, 160);
 			disconnectedColors[Bank::C] = Colour(140, 140, 140);
+			disconnectedColors[Bank::C1] = Colour(140, 140, 140);
+			disconnectedColors[Bank::C2] = Colour(140, 140, 140);
+			disconnectedColors[Bank::C3] = Colour(140, 140, 140);
+			disconnectedColors[Bank::C4] = Colour(140, 140, 140);
 			disconnectedColors[Bank::D] = Colour(120, 120, 120);
+			disconnectedColors[Bank::D1] = Colour(120, 120, 120);
+			disconnectedColors[Bank::D2] = Colour(120, 120, 120);
+			disconnectedColors[Bank::D3] = Colour(120, 120, 120);
+			disconnectedColors[Bank::D4] = Colour(120, 120, 120);
 			disconnectedColors[Bank::E] = Colour(180, 180, 180);
 			disconnectedColors[Bank::F] = Colour(160, 160, 160);
 			disconnectedColors[Bank::G] = Colour(140, 140, 140);
@@ -212,10 +230,8 @@ namespace OnixSourcePlugin
 				if (index > -1)
 				{
 					isOverElectrode = true;
-					electrodeInfoString = getElectrodeInfoString(index);
+					tooltipWindow->displayTip(event.getScreenPosition(), getElectrodeInfoString(index));
 				}
-
-				repaint();
 			}
 			else
 			{
@@ -224,7 +240,7 @@ namespace OnixSourcePlugin
 				if (isOverChannelNew != isOverElectrode)
 				{
 					isOverElectrode = isOverChannelNew;
-					repaint();
+					tooltipWindow->hideTip();
 				}
 			}
 		}
@@ -431,7 +447,7 @@ namespace OnixSourcePlugin
 			}
 
 			// draw channel numbers
-			g.setColour(Colours::grey);
+			g.setColour(findColour(ThemeColours::defaultText));
 			g.setFont(12);
 
 			int ch = 0;
@@ -461,7 +477,7 @@ namespace OnixSourcePlugin
 				false);
 
 			// draw shank outline
-			g.setColour(Colours::lightgrey);
+			g.setColour(findColour(ThemeColours::outline).withAlpha(0.75f));
 
 			for (int i = 0; i < settings->probeMetadata.shank_count; i++)
 			{
@@ -499,7 +515,7 @@ namespace OnixSourcePlugin
 
 					if (settings->electrodeMetadata[i].isSelected)
 					{
-						g.setColour(Colours::white);
+						g.setColour(findColour(ThemeColours::componentBackground).contrasting());
 						g.fillRect(xLoc, yLoc, electrodeHeight, electrodeHeight);
 					}
 
@@ -510,9 +526,9 @@ namespace OnixSourcePlugin
 			}
 
 			if (isOverZoomRegion)
-				g.setColour(Colour(25, 25, 25));
+				g.setColour(findColour(ThemeColours::outline));
 			else
-				g.setColour(Colour(55, 55, 55));
+				g.setColour(findColour(ThemeColours::outline).withAlpha(0.5f));
 
 			Path upperBorder;
 			upperBorder.startNewSubPath(5, lowerBound - zoomOffset - zoomHeight);
@@ -539,16 +555,6 @@ namespace OnixSourcePlugin
 			if (isSelectionActive)
 			{
 				g.setColour(Colours::white.withAlpha(0.5f));
-			}
-
-			if (isOverElectrode)
-			{
-				g.setColour(Colour(55, 55, 55));
-				g.setFont(15);
-				g.drawMultiLineText(electrodeInfoString,
-					250 + shankOffset + 45,
-					330,
-					250);
 			}
 		}
 
@@ -617,7 +623,7 @@ namespace OnixSourcePlugin
 
 		MouseCursor::StandardCursorType cursorType;
 
-		std::string electrodeInfoString;
+		std::unique_ptr<TooltipWindow> tooltipWindow;
 
 		Colour getElectrodeColour(int i)
 		{
@@ -655,7 +661,7 @@ namespace OnixSourcePlugin
 					else if (ref == "Tip")
 						return Colours::orange;
 					else
-						return Colours::black;
+						return Colours::purple;
 				}
 				else if (mode == VisualizationMode::ACTIVITY_VIEW)
 				{
@@ -768,14 +774,62 @@ namespace OnixSourcePlugin
 			case Bank::A:
 				a += "A";
 				break;
+			case Bank::A1:
+				a += "A1";
+				break;
+			case Bank::A2:
+				a += "A2";
+				break;
+			case Bank::A3:
+				a += "A3";
+				break;
+			case Bank::A4:
+				a += "A4";
+				break;
 			case Bank::B:
 				a += "B";
+				break;
+			case Bank::B1:
+				a += "B1";
+				break;
+			case Bank::B2:
+				a += "B2";
+				break;
+			case Bank::B3:
+				a += "B3";
+				break;
+			case Bank::B4:
+				a += "B4";
 				break;
 			case Bank::C:
 				a += "C";
 				break;
+			case Bank::C1:
+				a += "C1";
+				break;
+			case Bank::C2:
+				a += "C2";
+				break;
+			case Bank::C3:
+				a += "C3";
+				break;
+			case Bank::C4:
+				a += "C4";
+				break;
 			case Bank::D:
 				a += "D";
+				break;
+			case Bank::D1:
+				a += "D1";
+				break;
+			case Bank::D2:
+				a += "D2";
+				break;
+			case Bank::D3:
+				a += "D3";
+				break;
+			case Bank::D4:
+				a += "D4";
 				break;
 			case Bank::E:
 				a += "E";

--- a/Source/UI/SettingsInterface.h
+++ b/Source/UI/SettingsInterface.h
@@ -90,8 +90,8 @@ namespace OnixSourcePlugin
 		virtual void updateSettings() = 0;
 
 		std::shared_ptr<OnixDevice> getDevice() { return device; }
-
 		VisualizationMode getMode() const { return mode; }
+		Type getType() const { return type; }
 
 		virtual std::string getReferenceText() { return ""; }
 


### PR DESCRIPTION
This update mainly focuses on adding in the theme colors and extra banks that are possible with some Neuropixels probes. This now draws the lines / channels with the correct color so that they are visible; prior to this update some objects had the same color as the background, so it could be visualized in some themes.

- Fixes #41 