### PR TITLE
Use default index to open the next available context

### DIFF
--- a/Source/Onix1.h
+++ b/Source/Onix1.h
@@ -75,7 +75,7 @@ namespace OnixSourcePlugin
 	class Onix1
 	{
 	public:
-		Onix1(int hostIndex = 0);
+		Onix1(int hostIndex = -1);
 
 		~Onix1();
 


### PR DESCRIPTION
Instead of explicitly requesting the host at index `0`, we can use the default index `-1` to open the next available context, allowing for multiple plugins to be added to the same signal chain.

- Fixes #10 