### PR TITLE
Disable Output as a channel direction in AnalogIO

### DIFF
--- a/Source/UI/AnalogIOInterface.cpp
+++ b/Source/UI/AnalogIOInterface.cpp
@@ -67,6 +67,7 @@ AnalogIOInterface::AnalogIOInterface(std::shared_ptr<AnalogIO> d, OnixSourceEdit
 			channelDirectionComboBoxes[i]->setTooltip("Sets the direction of Channel " + std::to_string(i));
 			channelDirectionComboBoxes[i]->addItemList(directionList, 1);
 			channelDirectionComboBoxes[i]->setSelectedId(1, dontSendNotification);
+			channelDirectionComboBoxes[i]->setItemEnabled(2, false);
 			addAndMakeVisible(channelDirectionComboBoxes[i].get());
 
 			prevComboBoxRectangle = channelDirectionComboBoxes[i]->getBounds();


### PR DESCRIPTION
This leaves `Input` as the only option for the channel direction. Currently there is no functionality associated with `Output`, so it is disabled, but left as an option in case we add this functionality later.

- Fixes #95 