### PR TITLE
Remove uninitialized headstage ID

### DIFF
--- a/Source/OnixSource.cpp
+++ b/Source/OnixSource.cpp
@@ -430,7 +430,7 @@ bool OnixSource::initializeDevices(device_map_t deviceTable, bool updateStreamIn
 
 				hubNames.insert({ OnixDevice::getOffset(polledBno->getDeviceIdx()), NEUROPIXELSV2E_HEADSTAGE_NAME });
 			}
-			else if (hsid == 0xFFFFFFFF || hsid == ONIX_HUB_HSNP1ET || hsid == ONIX_HUB_HSNP1EH)
+			else if (hsid == ONIX_HUB_HSNP1ET || hsid == ONIX_HUB_HSNP1EH)
 			{
 				auto hubIndex = OnixDevice::getHubIndexFromPassthroughIndex(index);
 


### PR DESCRIPTION
- This was previously used for testing an uninitialized Neuropixels 1.0e headstage, but should not be left in the code base
- Fixes #92 