### PR TITLE
Add nullptr checks to avoid seg faults

### DIFF
--- a/Source/OnixSource.cpp
+++ b/Source/OnixSource.cpp
@@ -37,23 +37,17 @@ OnixSource::OnixSource(SourceNode* sn) :
 	}
 	catch (const std::system_error& e)
 	{
-		LOGE("Failed to create context. ", e.what());
-		CoreServices::sendStatusMessage("Failed to create context." + std::string(e.what()));
-		AlertWindow::showMessageBox(
-			MessageBoxIconType::WarningIcon,
+		Onix1::showWarningMessageBoxAsync(
 			"Failed to Create Context",
-			"There was an error creating the context. Check the error logs for more details."
+			e.what()
 		);
 		return;
 	}
 	catch (const error_t& e)
 	{
-		LOGE("Failed to initialize context. ", e.what());
-		CoreServices::sendStatusMessage("Failed to create context. " + std::string(e.what()));
-		AlertWindow::showMessageBox(
-			MessageBoxIconType::WarningIcon,
+		Onix1::showWarningMessageBoxAsync(
 			"Failed to Initialize Context",
-			"There was an error initializing the context. Check the error logs for more details."
+			e.what()
 		);
 		return;
 	}

--- a/Source/OnixSourceEditor.cpp
+++ b/Source/OnixSourceEditor.cpp
@@ -405,6 +405,9 @@ void OnixSourceEditor::comboBoxChanged(ComboBox* cb)
 
 void OnixSourceEditor::updateComboBox(ComboBox* cb)
 {
+	if (cb == nullptr)
+		return;
+
 	bool isPortA = cb == headstageComboBoxA.get();
 
 	PortName currentPort = isPortA ? PortName::PortA : PortName::PortB;
@@ -604,6 +607,9 @@ std::string OnixSourceEditor::getHeadstageSelected(PortName port)
 
 void OnixSourceEditor::setComboBoxSelection(ComboBox* comboBox, std::string headstage)
 {
+	if (comboBox == nullptr)
+		return;
+
 	String headstage_ = headstage;
 
 	for (int i = 0; i < comboBox->getNumItems(); i++)
@@ -651,6 +657,9 @@ OnixDeviceMap OnixSourceEditor::createTabMapFromCanvas()
 
 void OnixSourceEditor::saveVisualizerEditorParameters(XmlElement* xml)
 {
+	if (!source->isContextInitialized())
+		return;
+
 	LOGD("Saving OnixSourceEditor settings.");
 
 	xml->setAttribute("headstagePortA", headstageComboBoxA->getText());
@@ -664,6 +673,9 @@ void OnixSourceEditor::saveVisualizerEditorParameters(XmlElement* xml)
 
 void OnixSourceEditor::loadVisualizerEditorParameters(XmlElement* xml)
 {
+	if (!source->isContextInitialized())
+		return;
+
 	LOGD("Loading OnixSourceEditor settings.");
 
 	if (xml->hasAttribute("headstagePortA"))


### PR DESCRIPTION
- Now, if the context fails to initialize for any reason, the plugin no longer has hard crashes. The editor/canvas will present as blank elements, and the plugin must be removed and added to try again

- Fixes #108 