### PR TITLE
Remove ADC_CONFIG register write

### DIFF
--- a/Source/Devices/Neuropixels2e.cpp
+++ b/Source/Devices/Neuropixels2e.cpp
@@ -386,10 +386,6 @@ void Neuropixels2e::configureProbeStreaming()
 
 	// Activate recording mode on NP
 	probeControl->WriteByte(OP_MODE, 0b01000000);
-
-	// Set global ADC settings
-	// TODO: Undocumented
-	probeControl->WriteByte(ADC_CONFIG, 0b00001000);
 }
 
 void Neuropixels2e::configureSerDes()


### PR DESCRIPTION
No longer needed in `Neuropixels2e`.

- Fixes #111 