### PR TITLE
Update Neuropixels 2.0 Probes

### DIFF
--- a/Source/Devices/Neuropixels2e.cpp
+++ b/Source/Devices/Neuropixels2e.cpp
@@ -549,7 +549,7 @@ void Neuropixels2e::processFrames()
 				const size_t channelIndex = rawToChannel[j][i];
 
 				samples[probeIndex][channelIndex * numFrames + frameCount[probeIndex]] =
-					(float)(*(amplifierData + adcIndices[j] + adcDataOffset)) * gainCorrection[probeIndex];
+					(float)(*(amplifierData + adcIndices[j] + adcDataOffset)) * gainCorrection[probeIndex] + DataMidpoint;
 			}
 		}
 

--- a/Source/Devices/Neuropixels2e.h
+++ b/Source/Devices/Neuropixels2e.h
@@ -95,6 +95,9 @@ namespace OnixSourcePlugin
 
 		static constexpr int NumberOfProbes = 2;
 
+		static constexpr uint16_t NumberOfAdcBins = 4096;
+		static constexpr float DataMidpoint = NumberOfAdcBins / 2;
+
 		DataBuffer* amplifierBuffer[NumberOfProbes];
 
 		std::array<uint64_t, NumberOfProbes> probeSN;


### PR DESCRIPTION
This PR adds the final functionality to Neuropixels 2.0 probes after testing two of them simultaneously.

This also fixes the unsigned integer offset that was present due to naively converting from `uint` to `float` without finishing the conversion.

- Fixes #59 