### PR TITLE
Automatically search for calibration files for Neuropixels probes

### DIFF
--- a/Source/Devices/Neuropixels1e.cpp
+++ b/Source/Devices/Neuropixels1e.cpp
@@ -65,8 +65,7 @@ void NeuropixelsV1eBackgroundUpdater::run()
 	}
 	catch (const error_str& e)
 	{
-		LOGE(e.what());
-		AlertWindow::showMessageBox(MessageBoxIconType::WarningIcon, "Error Writing Shift Registers", e.what());
+		Onix1::showWarningMessageBoxAsync("Error Writing Shift Registers", e.what());
 		result = false;
 		return;
 	}

--- a/Source/OnixSource.cpp
+++ b/Source/OnixSource.cpp
@@ -159,8 +159,7 @@ bool OnixSource::configureDevice(OnixDeviceVector& sources,
 	}
 	catch (const error_str& e)
 	{
-		LOGE(e.what());
-		AlertWindow::showMessageBox(MessageBoxIconType::WarningIcon, "Configuration Error", e.what());
+		Onix1::showWarningMessageBoxAsync("Configuration Error", e.what());
 
 		return false;
 	}

--- a/Source/UI/NeuropixelsV1Interface.h
+++ b/Source/UI/NeuropixelsV1Interface.h
@@ -51,6 +51,7 @@ namespace OnixSourcePlugin
 
 		void buttonClicked(Button*) override;
 		void comboBoxChanged(ComboBox*) override;
+		void textEditorTextChanged(TextEditor&) override;
 
 		void startAcquisition() override;
 
@@ -77,6 +78,9 @@ namespace OnixSourcePlugin
 
 		bool acquisitionIsActive = false;
 
+		static constexpr char* GainCalibrationFilename = "_gainCalValues.csv";
+		static constexpr char* AdcCalibrationFilename = "_ADCCalibration.csv";
+
 		std::unique_ptr<ComboBox> electrodeConfigurationComboBox;
 		std::unique_ptr<ComboBox> lfpGainComboBox;
 		std::unique_ptr<ComboBox> apGainComboBox;
@@ -93,6 +97,20 @@ namespace OnixSourcePlugin
 		std::unique_ptr<Label> referenceLabel;
 		std::unique_ptr<Label> filterLabel;
 		std::unique_ptr<Label> activityViewLabel;
+
+		std::unique_ptr<Label> calibrationFolderLabel;
+		std::unique_ptr<ToggleButton> searchForCalibrationFilesButton;
+		std::unique_ptr<FileChooser> calibrationFolderChooser;
+		std::unique_ptr<TextEditor> calibrationFolder;
+		std::unique_ptr<UtilityButton> calibrationFolderButton;
+
+		void setCalibrationFolderEnabledState(bool enabledState);
+
+		static std::string searchDirectoryForGainCalibrationFile(std::string folder, uint64_t sn);
+		static std::string searchDirectoryForAdcCalibrationFile(std::string folder, uint64_t sn);
+		static std::string searchDirectoryForCalibrationFile(std::string folder, std::string filename, uint64_t sn);
+
+		void searchForCalibrationFiles(std::string, uint64_t);
 
 		std::unique_ptr<Label> adcCalibrationFileLabel;
 		std::unique_ptr<Label> gainCalibrationFileLabel;

--- a/Source/UI/NeuropixelsV2eProbeInterface.cpp
+++ b/Source/UI/NeuropixelsV2eProbeInterface.cpp
@@ -718,7 +718,7 @@ void NeuropixelsV2eProbeInterface::updateSettings()
 	gainCorrectionFile->setText(npx->getGainCorrectionFile(probeIndex) == "None" ? "" : npx->getGainCorrectionFile(probeIndex), dontSendNotification);
 }
 
-bool NeuropixelsV2eProbeInterface::applyProbeSettings(ProbeSettings<Neuropixels2e::numberOfChannels, Neuropixels2e::numberOfElectrodes>* p, bool shouldUpdateProbe)
+bool NeuropixelsV2eProbeInterface::applyProbeSettings(ProbeSettings<Neuropixels2e::numberOfChannels, Neuropixels2e::numberOfElectrodes>* p)
 {
 	if (electrodeConfigurationComboBox != 0)
 		electrodeConfigurationComboBox->setSelectedId(p->electrodeConfigurationIndex + 2, dontSendNotification);
@@ -747,11 +747,6 @@ bool NeuropixelsV2eProbeInterface::applyProbeSettings(ProbeSettings<Neuropixels2
 				settings->electrodeMetadata[j].status = ElectrodeStatus::CONNECTED;
 			}
 		}
-	}
-
-	if (shouldUpdateProbe)
-	{
-		CoreServices::saveRecoveryConfig();
 	}
 
 	drawLegend();

--- a/Source/UI/NeuropixelsV2eProbeInterface.h
+++ b/Source/UI/NeuropixelsV2eProbeInterface.h
@@ -58,7 +58,7 @@ namespace OnixSourcePlugin
 
 		void stopAcquisition() override;
 
-		bool applyProbeSettings(ProbeSettings<Neuropixels2e::numberOfChannels, Neuropixels2e::numberOfElectrodes>* p, bool shouldUpdateProbe = true);
+		bool applyProbeSettings(ProbeSettings<Neuropixels2e::numberOfChannels, Neuropixels2e::numberOfElectrodes>* p);
 
 		void saveParameters(XmlElement* xml) override;
 

--- a/Source/UI/NeuropixelsV2eProbeInterface.h
+++ b/Source/UI/NeuropixelsV2eProbeInterface.h
@@ -52,6 +52,7 @@ namespace OnixSourcePlugin
 
 		void buttonClicked(Button*) override;
 		void comboBoxChanged(ComboBox*) override;
+		void textEditorTextChanged(TextEditor&) override;
 
 		void startAcquisition() override;
 
@@ -77,6 +78,8 @@ namespace OnixSourcePlugin
 
 		const int probeIndex;
 
+		static constexpr char* GainCalibrationFilename = "_gainCalValues.csv";
+
 		std::unique_ptr<ComboBox> electrodeConfigurationComboBox;
 		std::unique_ptr<ComboBox> referenceComboBox;
 
@@ -85,6 +88,12 @@ namespace OnixSourcePlugin
 		std::unique_ptr<Label> electrodesLabel;
 		std::unique_ptr<Label> electrodePresetLabel;
 		std::unique_ptr<Label> referenceLabel;
+
+		std::unique_ptr<Label> gainCorrectionFolderLabel;
+		std::unique_ptr<ToggleButton> searchForCorrectionFilesButton;
+		std::unique_ptr<FileChooser> gainCorrectionFolderChooser;
+		std::unique_ptr<TextEditor> gainCorrectionFolder;
+		std::unique_ptr<UtilityButton> gainCorrectionFolderButton;
 
 		std::unique_ptr<Label> gainCorrectionFileLabel;
 		std::unique_ptr<UtilityButton> gainCorrectionFileButton;
@@ -127,6 +136,10 @@ namespace OnixSourcePlugin
 		void checkForExistingChannelPreset();
 
 		int getIndexOfComboBoxItem(ComboBox* cb, std::string item);
+
+		void setGainCorrectionFolderEnabledState(bool enabledState);
+
+		static std::string searchDirectoryForCalibrationFile(std::string folder, uint64_t sn);
 
 		JUCE_LEAK_DETECTOR(NeuropixelsV2eProbeInterface);
 	};


### PR DESCRIPTION
Instead of requiring the user to manually select the calibration files for each new probe, this PR adds a UI element to both Neuropixels 1.0 and 2.0 probe settings tabs that can automatically scan a folder for probe calibration files. The file has to be chosen by the user, but it can exist at an arbitrary location. 

- Fixes #134 

Any time one of the following conditions is true, the automatic scan will occur, and will attempt to find one and only one calibration file matching the given serial number:
- A new folder is chosen, and the probe serial number exists
- When a new probe serial number is found, and the folder already exists
- When the checkbox to automatically search through the folder is checked, if the folder is selected and a serial number exists

Folder paths and toggle state are saved in the XML. All UI elements are disabled during acquisition. 

This PR also adds a couple small commits related to optimizing the loading of the XML file (1307ab147e79087dc0cd4876f0fe0ec16c2f06cc) and only calling an alert window asynchronously to avoid conflicts with the message thread (615f6d86cde6ddbaa8977e02932c359ae9ee7a80) that came up during testing.
