### PR TITLE
Align read size to 32-bit word boundary

### DIFF
--- a/Source/OnixSourceEditor.cpp
+++ b/Source/OnixSourceEditor.cpp
@@ -237,6 +237,8 @@ void OnixSourceEditor::labelTextChanged (Label* l)
             readSize = maxReadSize;
         }
 
+        readSize = (readSize + 3) & ~3; // NB: Round up to the next multiple of four to align with word boundaries in liboni
+
         source->setBlockReadSize (readSize);
         l->setText (String (source->getBlockReadSize()), dontSendNotification);
     }

--- a/Source/OpenEphysLib.cpp
+++ b/Source/OpenEphysLib.cpp
@@ -47,7 +47,7 @@ extern "C" EXPORT void getLibInfo(Plugin::LibraryInfo* info)
 	info->name = "ONIX Source";
 
 	//Version of the library, used only for information
-	info->libVersion = "0.2.1";
+	info->libVersion = "0.3.0";
 	info->numPlugins = NUM_PLUGINS;
 }
 


### PR DESCRIPTION
Ensure that the read size is always a multiple of four to line up with the 32-bit word boundary needed for `liboni`.

Uses the same logic as the Onix1 library.

Fixes #149  