### PR TITLE
Add device metadata to Neuropixels probes

### DIFF
--- a/Source/OnixSource.cpp
+++ b/Source/OnixSource.cpp
@@ -820,7 +820,20 @@ void OnixSource::updateSettings (OwnedArray<ContinuousChannel>* continuousChanne
                     "imec"
                 };
 
-                deviceInfos->add (new DeviceInfo (deviceSettings));
+                auto device = new DeviceInfo (deviceSettings);
+
+                MetadataDescriptor descriptor (MetadataDescriptor::MetadataType::UINT16,
+                                               1,
+                                               "num_adcs",
+                                               "Number of analog-to-digital converter for this probe",
+                                               "neuropixels.adcs");
+
+                MetadataValue value (MetadataDescriptor::MetadataType::UINT16, 1);
+                value.setValue ((uint16) std::static_pointer_cast<Neuropixels1f> (source)->settings[0]->probeMetadata.num_adcs);
+
+                device->addMetadata (descriptor, value);
+
+                deviceInfos->add (device);
 
                 addIndividualStreams (source->streamInfos, dataStreams, deviceInfos, continuousChannels);
             }
@@ -856,7 +869,20 @@ void OnixSource::updateSettings (OwnedArray<ContinuousChannel>* continuousChanne
                     "imec"
                 };
 
-                deviceInfos->add (new DeviceInfo (deviceSettings));
+                auto device = new DeviceInfo (deviceSettings);
+
+                MetadataDescriptor descriptor (MetadataDescriptor::MetadataType::UINT16,
+                                               1,
+                                               "num_adcs",
+                                               "Number of analog-to-digital converter for this probe",
+                                               "neuropixels.adcs");
+
+                MetadataValue value (MetadataDescriptor::MetadataType::UINT16, 1);
+                value.setValue ((uint16) std::static_pointer_cast<Neuropixels2e> (source)->settings[0]->probeMetadata.num_adcs);
+
+                device->addMetadata (descriptor, value);
+
+                deviceInfos->add (device);
 
                 addIndividualStreams (source->streamInfos, dataStreams, deviceInfos, continuousChannels);
             }
@@ -937,7 +963,20 @@ void OnixSource::updateSettings (OwnedArray<ContinuousChannel>* continuousChanne
                     "imec"
                 };
 
-                deviceInfos->add (new DeviceInfo (deviceSettings));
+                auto device = new DeviceInfo (deviceSettings);
+
+                MetadataDescriptor descriptor (MetadataDescriptor::MetadataType::UINT16,
+                                               1,
+                                               "num_adcs",
+                                               "Number of analog-to-digital converter for this probe",
+                                               "neuropixels.adcs");
+
+                MetadataValue value (MetadataDescriptor::MetadataType::UINT16, 1);
+                value.setValue ((uint16) std::static_pointer_cast<Neuropixels1e> (source)->settings[0]->probeMetadata.num_adcs);
+
+                device->addMetadata (descriptor, value);
+
+                deviceInfos->add (device);
 
                 addIndividualStreams (source->streamInfos, dataStreams, deviceInfos, continuousChannels);
             }


### PR DESCRIPTION
Define the number of ADCs per probe now, which should allow it to work with the Neuropixels-CAR plugin.

@jsiegle @anjaldoshi I have a question about the usage of the CAR plugin; during testing, I had to open the sidebar to see all of the streams and then choose a Neuropixels stream before it would register that it had a valid Neuropixels probe in the streams. Is there a way to update the plugin so that it maybe has a dropdown menu of all valid Neuropixels streams? Since the ONIX source has several device streams that are not Neuropixels, it could be confusing/annoying for users to have to open the sidebar and blindly choose streams until they get the one they want. On a related note, the streams pop-up does not have enough width to display the full stream name, so it cuts off and users might not be able to see the difference between the AP/LFP streams for Neuropixels 1.0.

Fixes #146 