### PR TITLE
Add depth and shank information to Neuropixels channels

### DIFF
--- a/Source/Devices/Neuropixels1e.cpp
+++ b/Source/Devices/Neuropixels1e.cpp
@@ -135,6 +135,8 @@ int Neuropixels1e::configureDevice()
 
     LOGD ("Probe SN: ", probeMetadata.getProbeSerialNumber());
 
+    settings[0]->connected = probeMetadata.getProbeSerialNumber() != 0;
+
     return ONI_ESUCCESS;
 }
 

--- a/Source/Devices/Neuropixels1f.cpp
+++ b/Source/Devices/Neuropixels1f.cpp
@@ -127,6 +127,8 @@ int Neuropixels1f::configureDevice()
 
     LOGD ("Probe SN: ", probeMetadata.getProbeSerialNumber());
 
+    settings[0]->connected = probeMetadata.getProbeSerialNumber() != 0;
+
     // Enable device streaming
     rc = deviceContext->writeRegister (deviceIdx, 0x8000, 1);
     if (rc != ONI_ESUCCESS)

--- a/Source/NeuropixelsComponents.h
+++ b/Source/NeuropixelsComponents.h
@@ -287,6 +287,7 @@ struct ProbeSettings
         lfpGainIndex = newSettings->lfpGainIndex;
         referenceIndex = newSettings->referenceIndex;
         apFilterState = newSettings->apFilterState;
+        connected = newSettings->connected;
 
         selectedBank = newSettings->selectedBank;
         selectedShank = newSettings->selectedShank;
@@ -344,6 +345,7 @@ struct ProbeSettings
     int lfpGainIndex = 0;
     int referenceIndex = 0;
     bool apFilterState = false;
+    bool connected = false;
 
     std::vector<Bank> selectedBank;
     std::vector<int> selectedShank;
@@ -575,6 +577,9 @@ public:
         for (auto it = probeSettings.rbegin(); it != probeSettings.rend(); it++)
         {
             ProbeSettings* probeSetting = it->get();
+
+            if (! probeSetting->connected)
+                continue;
 
             for (int i = probeSetting->numberOfChannels - 1; i >= 0; i--)
             {

--- a/Source/OnixSource.cpp
+++ b/Source/OnixSource.cpp
@@ -836,6 +836,8 @@ void OnixSource::updateSettings (OwnedArray<ContinuousChannel>* continuousChanne
                 deviceInfos->add (device);
 
                 addIndividualStreams (source->streamInfos, dataStreams, deviceInfos, continuousChannels);
+
+                NeuropixelsHelpers::setChannelMetadata (continuousChannels, std::static_pointer_cast<Neuropixels1f> (source)->settings);
             }
             else if (type == OnixDeviceType::BNO || type == OnixDeviceType::POLLEDBNO)
             {
@@ -885,6 +887,8 @@ void OnixSource::updateSettings (OwnedArray<ContinuousChannel>* continuousChanne
                 deviceInfos->add (device);
 
                 addIndividualStreams (source->streamInfos, dataStreams, deviceInfos, continuousChannels);
+
+                NeuropixelsHelpers::setChannelMetadata (continuousChannels, std::static_pointer_cast<Neuropixels2e> (source)->settings);
             }
             else if (type == OnixDeviceType::MEMORYMONITOR)
             {
@@ -979,6 +983,8 @@ void OnixSource::updateSettings (OwnedArray<ContinuousChannel>* continuousChanne
                 deviceInfos->add (device);
 
                 addIndividualStreams (source->streamInfos, dataStreams, deviceInfos, continuousChannels);
+
+                NeuropixelsHelpers::setChannelMetadata (continuousChannels, std::static_pointer_cast<Neuropixels1e> (source)->settings);
             }
             else if (type == OnixDeviceType::OUTPUTCLOCK)
             {

--- a/Source/UI/NeuropixelsV1Interface.cpp
+++ b/Source/UI/NeuropixelsV1Interface.cpp
@@ -925,6 +925,8 @@ void NeuropixelsV1Interface::selectElectrodes (std::vector<int> electrodes)
 {
     std::static_pointer_cast<Neuropixels1> (device)->settings[0]->selectElectrodes (electrodes);
 
+    CoreServices::updateSignalChain (editor);
+
     repaint();
 }
 

--- a/Source/UI/NeuropixelsV2eProbeInterface.cpp
+++ b/Source/UI/NeuropixelsV2eProbeInterface.cpp
@@ -682,6 +682,8 @@ void NeuropixelsV2eProbeInterface::selectElectrodes (std::vector<int> electrodes
 {
     std::static_pointer_cast<Neuropixels2e> (device)->settings[probeIndex]->selectElectrodes (electrodes);
 
+    CoreServices::updateSignalChain (editor);
+
     repaint();
 }
 


### PR DESCRIPTION
Similar to how the [Neuropixels PXI plugin](https://github.com/open-ephys-plugins/neuropixels-pxi/commit/107c5a7b29a2bedf22101a828c5c1f4290991002) adds metadata and channel information to the continuous channels, we are adding the same information here. This allows us to take advantage of features in the LFP viewer such as Sort by Depth, and grouping colours By Shank.

Fixes #138  